### PR TITLE
Add /delegates routing

### DIFF
--- a/src/routes/delegates/handlers.rs
+++ b/src/routes/delegates/handlers.rs
@@ -1,0 +1,123 @@
+use crate::common::models::page::Page;
+use crate::providers::info::DefaultInfoProvider;
+use crate::providers::info::InfoProvider;
+use crate::routes::delegates::models::{
+    Delegate, DelegateCreate, DelegateDelete, SafeDelegateDelete,
+};
+use crate::utils::context::Context;
+use crate::utils::errors::{ApiError, ApiResult};
+
+pub async fn get_delegates(
+    context: Context<'_>,
+    chain_id: String,
+    safe: Option<String>,
+    delegate: Option<String>,
+    delegator: Option<String>,
+    label: Option<String>,
+) -> ApiResult<Page<Delegate>> {
+    let info_provider = DefaultInfoProvider::new(&chain_id, &context);
+    let url = core_uri!(
+        info_provider,
+        "/v1/delegates/?safe={}&delegate={}&delegator={}&label={}",
+        safe.unwrap_or(String::from("")),
+        delegate.unwrap_or(String::from("")),
+        delegator.unwrap_or(String::from("")),
+        label.unwrap_or(String::from("")),
+    )?;
+
+    let safe_delegates: Page<Delegate> = context
+        .client()
+        .get(&url)
+        .send()
+        .await?
+        .json::<Page<Delegate>>()
+        .await?;
+
+    return Ok(safe_delegates);
+}
+
+pub async fn post_delegate(
+    context: Context<'_>,
+    chain_id: String,
+    safe_delegate_create: DelegateCreate,
+) -> ApiResult<()> {
+    let info_provider = DefaultInfoProvider::new(&chain_id, &context);
+    let url = core_uri!(info_provider, "/v1/delegates/",)?;
+
+    let response = context
+        .client()
+        .post(&url)
+        .json(&safe_delegate_create)
+        .send()
+        .await?;
+
+    return if response.status().is_success() {
+        Ok(())
+    } else {
+        Err(ApiError::from_http_response(
+            response,
+            String::from("Unexpected delegate creation error"),
+        )
+        .await)
+    };
+}
+
+pub async fn delete_delegate(
+    context: Context<'_>,
+    chain_id: String,
+    delegate_address: String,
+    delegate_delete: DelegateDelete,
+) -> ApiResult<()> {
+    let info_provider = DefaultInfoProvider::new(&chain_id, &context);
+    let url = core_uri!(info_provider, "/v1/delegates/{}", delegate_address)?;
+
+    let response = context
+        .client()
+        .delete(&url)
+        .json(&delegate_delete)
+        .send()
+        .await?;
+
+    return if response.status().is_success() {
+        Ok(())
+    } else {
+        Err(ApiError::from_http_response(
+            response,
+            String::from("Unexpected delegate deletion error"),
+        )
+        .await)
+    };
+}
+
+pub async fn delete_safe_delegate(
+    context: Context<'_>,
+    chain_id: String,
+    safe_address: String,
+    delegate_address: String,
+    safe_delegate_delete: SafeDelegateDelete,
+) -> ApiResult<()> {
+    let info_provider = DefaultInfoProvider::new(&chain_id, &context);
+    let url = core_uri!(
+        info_provider,
+        "/v1/safes/{}/delegates/{}",
+        safe_address,
+        delegate_address
+    )?;
+
+    let response = context
+        .client()
+        .delete(&url)
+        .json(&safe_delegate_delete)
+        .send()
+        .await?;
+
+    return if response.status().is_success() {
+        Ok(())
+    } else {
+        Err(ApiError::from_http_response(
+            response,
+            String::from("Unexpected delegate deletion error"),
+        )
+        .await)
+    };
+}

--- a/src/routes/delegates/mod.rs
+++ b/src/routes/delegates/mod.rs
@@ -1,0 +1,4 @@
+#[doc(hidden)]
+mod handlers;
+mod models;
+pub mod routes;

--- a/src/routes/delegates/models.rs
+++ b/src/routes/delegates/models.rs
@@ -1,0 +1,36 @@
+use serde::{Deserialize, Serialize};
+
+#[derive(Serialize, Deserialize)]
+#[serde(rename_all = "camelCase")]
+pub struct Delegate {
+    safe: String,
+    delegate: String,
+    delegator: String,
+    label: String,
+}
+
+#[derive(Serialize, Deserialize)]
+#[serde(rename_all = "camelCase")]
+pub struct DelegateCreate {
+    safe: Option<String>,
+    delegate: String,
+    delegator: String,
+    signature: String,
+    label: String,
+}
+
+#[derive(Serialize, Deserialize)]
+#[serde(rename_all = "camelCase")]
+pub struct DelegateDelete {
+    delegate: String,
+    delegator: String,
+    signature: String,
+}
+
+#[derive(Serialize, Deserialize)]
+#[serde(rename_all = "camelCase")]
+pub struct SafeDelegateDelete {
+    safe: String,
+    delegate: String,
+    signature: String,
+}

--- a/src/routes/delegates/routes.rs
+++ b/src/routes/delegates/routes.rs
@@ -1,0 +1,73 @@
+use crate::routes::delegates::handlers;
+use crate::routes::delegates::models::{DelegateCreate, DelegateDelete, SafeDelegateDelete};
+use crate::utils::context::Context;
+use crate::utils::errors::ApiResult;
+use rocket::response::content;
+use rocket::serde::json::Json;
+
+#[get(
+    "/v1/chains/<chain_id>/delegates?<safe>&<delegate>&<delegator>&<label>",
+    format = "application/json"
+)]
+pub async fn get_delegates<'e>(
+    context: Context<'_>,
+    chain_id: String,
+    safe: Option<String>,
+    delegate: Option<String>,
+    delegator: Option<String>,
+    label: Option<String>,
+) -> ApiResult<content::Json<String>> {
+    let json = serde_json::to_string(
+        &handlers::get_delegates(context, chain_id, safe, delegate, delegator, label).await?,
+    )?;
+    Ok(content::Json(json))
+}
+
+#[post(
+    "/v1/chains/<chain_id>/delegates",
+    format = "application/json",
+    data = "<safe_delegate>"
+)]
+pub async fn post_delegate<'e>(
+    context: Context<'_>,
+    chain_id: String,
+    safe_delegate: Json<DelegateCreate>,
+) -> ApiResult<()> {
+    return handlers::post_delegate(context, chain_id, safe_delegate.0).await;
+}
+
+#[delete(
+    "/v1/chains/<chain_id>/delegates/<delegate_address>",
+    format = "application/json",
+    data = "<delegate_delete>"
+)]
+pub async fn delete_delegate<'e>(
+    context: Context<'_>,
+    chain_id: String,
+    delegate_address: String,
+    delegate_delete: Json<DelegateDelete>,
+) -> ApiResult<()> {
+    return handlers::delete_delegate(context, chain_id, delegate_address, delegate_delete.0).await;
+}
+
+#[delete(
+    "/v1/chains/<chain_id>/safes/<safe_address>/delegates/<delegate_address>",
+    format = "application/json",
+    data = "<delegate_delete>"
+)]
+pub async fn delete_safe_delegate<'e>(
+    context: Context<'_>,
+    chain_id: String,
+    safe_address: String,
+    delegate_address: String,
+    delegate_delete: Json<SafeDelegateDelete>,
+) -> ApiResult<()> {
+    return handlers::delete_safe_delegate(
+        context,
+        chain_id,
+        safe_address,
+        delegate_address,
+        delegate_delete.0,
+    )
+    .await;
+}

--- a/src/routes/mod.rs
+++ b/src/routes/mod.rs
@@ -15,6 +15,7 @@ pub mod chains;
 pub mod collectibles;
 /// # Utility endpoints
 pub mod contracts;
+pub mod delegates;
 #[doc(hidden)]
 pub mod health;
 #[doc(hidden)]
@@ -47,6 +48,10 @@ pub fn active_routes() -> Vec<Route> {
         chains::routes::get_chains,
         collectibles::routes::get_collectibles,
         contracts::routes::post_data_decoder,
+        delegates::routes::delete_delegate,
+        delegates::routes::delete_safe_delegate,
+        delegates::routes::get_delegates,
+        delegates::routes::post_delegate,
         notifications::routes::post_notification_registration,
         notifications::routes::delete_notification_registration,
         safes::routes::get_safe_info,


### PR DESCRIPTION
Closes #650 

- Implement routing for the `/delegates` feature
- Forwards the following endpoints to the core services:
  * `GET /v1/chains/<chain_id>/delegates?<safe>&<delegate>&<delegator>&<label>` to `GET /v1/delegates/?safe=<safe>&delegate=<delegate>&delegator=<delegator>&label=<label>`
  *  `POST /v1/chains/<chain_id>/delegates` to `POST /v1/delegates/`
  * `DELETE /v1/chains/<chain_id>/delegates/<delegate_address>` to `DELETE /v1/delegates/<delegate_address>`
  * `DELETE /v1/chains/<chain_id>/safes/<safe_address>/delegates/<delegate_address>` to `DELETE /v1/safes/<safe_address>/delegates/<delegate_address>`