### PR TITLE
Bump rustc to 1.56.0

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,5 +1,5 @@
 # Build Image
-FROM rust:1.55.0-slim-buster as builder
+FROM rust:1.56.0-slim-buster as builder
 
 RUN set -ex; \ 
   apt-get update; \

--- a/rust-toolchain.toml
+++ b/rust-toolchain.toml
@@ -1,2 +1,2 @@
 [toolchain]
-channel = "1.55.0"
+channel = "1.56.0"


### PR DESCRIPTION
- Update `rustc` to version 1.56.0 – https://blog.rust-lang.org/2021/10/21/Rust-1.56.0.html