### PR TITLE
Transfer parameters fetched by index, not by name

### DIFF
--- a/src/routes/transactions/converters/mod.rs
+++ b/src/routes/transactions/converters/mod.rs
@@ -116,11 +116,12 @@ impl SafeTransaction {
                 token_name: Some(token.name.to_owned()),
                 token_symbol: Some(token.symbol.to_owned()),
                 decimals: Some(token.decimals),
-                value: self
-                    .data_decoded
-                    .as_ref()
-                    .and_then(|it| it.get_parameter_single_value("value"))
-                    .unwrap_or(String::from("0")),
+                value: get_value_param(&self.data_decoded, "0"),
+                // self
+                //     .data_decoded
+                //     .as_ref()
+                //     .and_then(|it| it.get_parameter_single_value("value"))
+                //     .unwrap_or(String::from("0")),
             }),
         }
     }
@@ -145,14 +146,15 @@ impl SafeTransaction {
                 logo_uri: token.logo_uri.to_owned(),
                 token_name: Some(token.name.to_owned()),
                 token_symbol: Some(token.symbol.to_owned()),
-                token_id: self
-                    .data_decoded
-                    .as_ref()
-                    .and_then(|it| match it.get_parameter_single_value("tokenId") {
-                        Some(e) => Some(e),
-                        None => it.get_parameter_single_value("value"),
-                    })
-                    .unwrap_or(String::from("0")),
+                token_id: get_value_param(&self.data_decoded, "0"),
+                // self
+                //     .data_decoded
+                //     .as_ref()
+                //     .and_then(|it| match it.get_parameter_single_value("tokenId") {
+                //         Some(e) => Some(e),
+                //         None => it.get_parameter_single_value("value"),
+                //     })
+                //     .unwrap_or(String::from("0")),
             }),
         }
     }
@@ -320,26 +322,36 @@ fn data_size(data: &Option<String>) -> usize {
 fn get_from_param(data_decoded: &Option<DataDecoded>, fallback: &str) -> String {
     data_decoded
         .as_ref()
-        .map(|data_decoded| match data_decoded.method.as_str() {
+        .and_then(|data_decoded| match data_decoded.method.as_str() {
             TRANSFER_METHOD => None,
             TRANSFER_FROM_METHOD => data_decoded.get_parameter_single_value_at(0),
             SAFE_TRANSFER_FROM_METHOD => data_decoded.get_parameter_single_value_at(0),
             _ => None,
         })
-        .flatten()
         .unwrap_or(String::from(fallback))
 }
 
 fn get_to_param(data_decoded: &Option<DataDecoded>, fallback: &str) -> String {
     data_decoded
         .as_ref()
-        .map(|data_decoded| match data_decoded.method.as_str() {
+        .and_then(|data_decoded| match data_decoded.method.as_str() {
             TRANSFER_METHOD => data_decoded.get_parameter_single_value_at(0),
             TRANSFER_FROM_METHOD => data_decoded.get_parameter_single_value_at(1),
             SAFE_TRANSFER_FROM_METHOD => data_decoded.get_parameter_single_value_at(1),
             _ => None,
         })
-        .flatten()
+        .unwrap_or(String::from(fallback))
+}
+
+fn get_value_param(data_decoded: &Option<DataDecoded>, fallback: &str) -> String {
+    data_decoded
+        .as_ref()
+        .and_then(|data_decoded| match data_decoded.method.as_str() {
+            TRANSFER_METHOD => data_decoded.get_parameter_single_value_at(1),
+            TRANSFER_FROM_METHOD => data_decoded.get_parameter_single_value_at(2),
+            SAFE_TRANSFER_FROM_METHOD => data_decoded.get_parameter_single_value_at(2),
+            _ => None,
+        })
         .unwrap_or(String::from(fallback))
 }
 

--- a/src/routes/transactions/converters/mod.rs
+++ b/src/routes/transactions/converters/mod.rs
@@ -117,11 +117,6 @@ impl SafeTransaction {
                 token_symbol: Some(token.symbol.to_owned()),
                 decimals: Some(token.decimals),
                 value: get_value_param(&self.data_decoded, "0"),
-                // self
-                //     .data_decoded
-                //     .as_ref()
-                //     .and_then(|it| it.get_parameter_single_value("value"))
-                //     .unwrap_or(String::from("0")),
             }),
         }
     }
@@ -147,14 +142,6 @@ impl SafeTransaction {
                 token_name: Some(token.name.to_owned()),
                 token_symbol: Some(token.symbol.to_owned()),
                 token_id: get_value_param(&self.data_decoded, "0"),
-                // self
-                //     .data_decoded
-                //     .as_ref()
-                //     .and_then(|it| match it.get_parameter_single_value("tokenId") {
-                //         Some(e) => Some(e),
-                //         None => it.get_parameter_single_value("value"),
-                //     })
-                //     .unwrap_or(String::from("0")),
             }),
         }
     }

--- a/src/routes/transactions/converters/mod.rs
+++ b/src/routes/transactions/converters/mod.rs
@@ -101,7 +101,10 @@ impl SafeTransaction {
         info_provider: &impl InfoProvider,
     ) -> Transfer {
         let sender = get_from_param(&self.data_decoded, &self.safe);
-        let recipient = get_to_param(&self.data_decoded, "0x0");
+        let recipient = get_to_param(
+            &self.data_decoded,
+            "0x0000000000000000000000000000000000000000",
+        );
         let direction = get_transfer_direction(&self.safe, &sender, &recipient);
         Transfer {
             sender: get_address_ex_from_any_source(&self.safe, &sender, info_provider).await,
@@ -128,7 +131,10 @@ impl SafeTransaction {
         info_provider: &impl InfoProvider,
     ) -> Transfer {
         let sender = get_from_param(&self.data_decoded, &self.safe);
-        let recipient = get_to_param(&self.data_decoded, "0x0");
+        let recipient = get_to_param(
+            &self.data_decoded,
+            "0x0000000000000000000000000000000000000000",
+        );
         let direction = get_transfer_direction(&self.safe, &sender, &recipient);
         Transfer {
             sender: get_address_ex_from_any_source(&self.safe, &sender, info_provider).await,

--- a/src/routes/transactions/converters/tests/check_sender_or_receiver.rs
+++ b/src/routes/transactions/converters/tests/check_sender_or_receiver.rs
@@ -37,40 +37,6 @@ fn check_sender_or_receiver_safe_receiver() {
 }
 
 #[test]
-fn check_sender_or_receiver_safe_wrong_method_correct_sender() {
-    let data_decoded = Some(DataDecoded {
-        method: "wrong_transfer_method".to_string(),
-        parameters: Some(vec![Parameter {
-            name: "from".to_string(),
-            param_type: "address".to_string(),
-            value: SingleValue("0x1230B3d59858296A31053C1b8562Ecf89A2f888b".to_string()),
-            value_decoded: None,
-        }]),
-    });
-
-    let actual =
-        check_sender_or_receiver(&data_decoded, "0x1230B3d59858296A31053C1b8562Ecf89A2f888b");
-    assert!(actual);
-}
-
-#[test]
-fn check_sender_or_receiver_method_wrong_correct_recipient() {
-    let data_decoded = Some(DataDecoded {
-        method: "wrong_transfer_method".to_string(),
-        parameters: Some(vec![Parameter {
-            name: "to".to_string(),
-            param_type: "address".to_string(),
-            value: SingleValue("0x1230B3d59858296A31053C1b8562Ecf89A2f888b".to_string()),
-            value_decoded: None,
-        }]),
-    });
-
-    let actual =
-        check_sender_or_receiver(&data_decoded, "0x1230B3d59858296A31053C1b8562Ecf89A2f888b");
-    assert!(actual);
-}
-
-#[test]
 fn check_sender_or_receiver_safe_invalid_sender() {
     let data_decoded = Some(DataDecoded {
         method: "transfer".to_string(),

--- a/src/tests/json/mod.rs
+++ b/src/tests/json/mod.rs
@@ -67,6 +67,8 @@ pub const ERC_20_TRANSFER_WITH_TOKEN_INFO_INCOMING: &str =
     include_str!("transfers/erc_20_transfer_with_token_info_incoming.json");
 pub const ERC_20_TRANSFER_WITH_TOKEN_INFO_OUTGOING: &str =
     include_str!("transfers/erc_20_transfer_with_token_info_outgoing.json");
+pub const ERC_20_TRANSFER_UNEXPECTED_PARAM_NAMES: &str =
+    include_str!("transfers/erc_20_transfer_unexpected_param_names.json");
 pub const ERC_721_TRANSFER_WITHOUT_TOKEN_INFO: &str =
     include_str!("transfers/erc_721_transfer_without_token_info.json");
 pub const ERC_721_TRANSFER_WITH_TOKEN_INFO_INCOMING: &str =

--- a/src/tests/json/transfers/erc_20_transfer_unexpected_param_names.json
+++ b/src/tests/json/transfers/erc_20_transfer_unexpected_param_names.json
@@ -1,0 +1,59 @@
+{
+    "safe": "0x1C8b9B78e3085866521FE206fa4c1a67F49f153A",
+    "to": "0xc778417E063141139Fce010982780140Aa0cD5Ab",
+    "value": "0",
+    "data": "0xa9059cbb0000000000000000000000001c8b9b78e3085866521fe206fa4c1a67f49f153a000000000000000000000000000000000000000000000000002386f26fc10000",
+    "operation": 0,
+    "gasToken": "0x0000000000000000000000000000000000000000",
+    "safeTxGas": 0,
+    "baseGas": 0,
+    "gasPrice": "0",
+    "refundReceiver": "0x0000000000000000000000000000000000000000",
+    "nonce": 388,
+    "executionDate": "2022-01-17T09:03:41Z",
+    "submissionDate": "2022-01-06T15:38:30.563130Z",
+    "modified": "2022-01-17T09:04:07.223308Z",
+    "blockNumber": 10005930,
+    "transactionHash": "0xd0b5e6ce2685c680f7c7e2b1c03bb94ec704d16c19a2b834eac1fd06d7e5f6d9",
+    "safeTxHash": "0x0437839bd4e5449c474b93328b1e27eb2f387e71eb0992f09da7ba4d484905a7",
+    "executor": "0xD28293bf13549Abb49Ed1D83D515301A05E3Fc8d",
+    "isExecuted": true,
+    "isSuccessful": true,
+    "ethGasPrice": "1500000057",
+    "gasUsed": 65010,
+    "fee": "97515003705570",
+    "origin": null,
+    "dataDecoded": {
+        "method": "transfer",
+        "parameters": [
+            {
+                "name": "dst",
+                "type": "address",
+                "value": "0x1C8b9B78e3085866521FE206fa4c1a67F49f153A"
+            },
+            {
+                "name": "wad",
+                "type": "uint256",
+                "value": "10000000000000000"
+            }
+        ]
+    },
+    "confirmationsRequired": 2,
+    "confirmations": [
+        {
+            "owner": "0xE86935943315293154c7AD63296b4e1adAc76364",
+            "submissionDate": "2022-01-06T15:38:30.587408Z",
+            "transactionHash": null,
+            "signature": "0xcfde7a3d0aa3dd52db66ebcd3518b3d667184f390c0eac09c608ed21ce80c8cb22a2b494febc18da555d236a81fdab4d3adcde3c58e1e67c0cf869ada30fb1ea1c",
+            "signatureType": "EOA"
+        },
+        {
+            "owner": "0x5c9E7b93900536D9cc5559b881375Bae93c933D0",
+            "submissionDate": "2022-01-10T16:48:07.329109Z",
+            "transactionHash": null,
+            "signature": "0xf464c18947105d68781095f547211a5b8c834b6b1d6cd87a8a7dd43cfc33821e71b7ef1dd83ad5a5739961b381f3555e6f0125faf56b728878fec847e7eec5a71b",
+            "signatureType": "EOA"
+        }
+    ],
+    "signatures": "0xf464c18947105d68781095f547211a5b8c834b6b1d6cd87a8a7dd43cfc33821e71b7ef1dd83ad5a5739961b381f3555e6f0125faf56b728878fec847e7eec5a71bcfde7a3d0aa3dd52db66ebcd3518b3d667184f390c0eac09c608ed21ce80c8cb22a2b494febc18da555d236a81fdab4d3adcde3c58e1e67c0cf869ada30fb1ea1c"
+}

--- a/src/utils/mod.rs
+++ b/src/utils/mod.rs
@@ -15,8 +15,14 @@ pub mod urls;
 mod tests;
 
 pub const TRANSFER_METHOD: &str = "transfer";
-pub const ERC20_TRANSFER_METHODS: &[&str] = &[TRANSFER_METHOD, "transferFrom"];
-pub const ERC721_TRANSFER_METHODS: &[&str] = &[TRANSFER_METHOD, "transferFrom", "safeTransferFrom"];
+pub const TRANSFER_FROM_METHOD: &str = "transferFrom";
+pub const SAFE_TRANSFER_FROM_METHOD: &str = "safeTransferFrom";
+pub const ERC20_TRANSFER_METHODS: &[&str] = &[TRANSFER_METHOD, TRANSFER_FROM_METHOD];
+pub const ERC721_TRANSFER_METHODS: &[&str] = &[
+    TRANSFER_METHOD,
+    TRANSFER_FROM_METHOD,
+    SAFE_TRANSFER_FROM_METHOD,
+];
 
 pub const SET_FALLBACK_HANDLER: &'static str = "setFallbackHandler";
 pub const ADD_OWNER_WITH_THRESHOLD: &'static str = "addOwnerWithThreshold";


### PR DESCRIPTION
Closes #784 

References:
- https://eips.ethereum.org/EIPS/eip-20
- https://eips.ethereum.org/EIPS/eip-721

Notes: 
- There are 2 tests that for some reason try to ignore the method name that were added at some point. I propose to remove them as they seem to be flat out wrong:
https://github.com/gnosis/safe-client-gateway/blob/e43b2175d653cca6ae835c2459668f544ac3b4c3/src/routes/transactions/converters/tests/check_sender_or_receiver.rs#L40
https://github.com/gnosis/safe-client-gateway/blob/e43b2175d653cca6ae835c2459668f544ac3b4c3/src/routes/transactions/converters/tests/check_sender_or_receiver.rs#L57

- I've included a test covering the issue `transfer` case (unexpected paramter names)