### PR TITLE
Fix /notification/devices error mapping

### DIFF
--- a/src/routes/notifications/handlers.rs
+++ b/src/routes/notifications/handlers.rs
@@ -63,13 +63,13 @@ pub async fn post_registration(
     for (chain_id, request) in requests.into_iter() {
         match request.await {
             Err(api_error) => {
-                let notification_registration_error = NotificationRegistrationError {
+                errors.push(
+                    NotificationRegistrationError {
                     status_code: api_error.status,
                     chain_id: String::from(chain_id),
                     error: json!(
                             {chain_id :   RawValue::from_string(api_error.details.message.unwrap_or(String::from("Unknown notification registration issue")))?}),
-                };
-                errors.push(notification_registration_error);
+                });
             }
             _ => {}
         }

--- a/src/routes/notifications/handlers.rs
+++ b/src/routes/notifications/handlers.rs
@@ -1,14 +1,16 @@
+use itertools::Itertools;
+use serde_json::json;
+use serde_json::value::RawValue;
+use serde_json::{self, value::Value};
+
 use crate::common::models::backend::notifications::NotificationRegistrationRequest as BackendRegistrationRequest;
 use crate::providers::info::{DefaultInfoProvider, InfoProvider};
 use crate::routes::notifications::models::{
     DeviceData, NotificationRegistrationRequest, SafeRegistration,
 };
 use crate::utils::context::RequestContext;
-use crate::utils::errors::{ApiError, ApiResult};
+use crate::utils::errors::{ApiError, ApiResult, ErrorDetails};
 use crate::utils::http_client::Request;
-use serde_json::json;
-use serde_json::value::RawValue;
-use serde_json::{self, value::Value};
 
 pub async fn delete_registration(
     context: &RequestContext,
@@ -28,6 +30,12 @@ pub async fn delete_registration(
     context.http_client().delete(request).await?;
 
     Ok(())
+}
+
+struct NotificationRegistrationError {
+    status_code: u16,
+    chain_id: String,
+    error: Value,
 }
 
 pub async fn post_registration(
@@ -51,33 +59,46 @@ pub async fn post_registration(
         requests.push((&safe_registration.chain_id, client.post(request)));
     }
 
-    let (error_chain_ids, error_body) = {
-        let mut error_chain_ids: Vec<&str> = vec![];
-        let mut errors: Vec<Value> = vec![];
-        for (chain_id, request) in requests.into_iter() {
-            match request.await {
-                Err(api_error) => {
-                    error_chain_ids.push(chain_id);
-                    errors.push(json!({
-                        chain_id :   RawValue::from_string(api_error.details.message.unwrap_or(String::from("Unknown notification registration issue")))?
-                    }))
-                }
-                _ => {}
+    let mut errors: Vec<NotificationRegistrationError> = vec![];
+    for (chain_id, request) in requests.into_iter() {
+        match request.await {
+            Err(api_error) => {
+                let notification_registration_error = NotificationRegistrationError {
+                    status_code: api_error.status,
+                    chain_id: String::from(chain_id),
+                    error: json!(
+                            {chain_id :   RawValue::from_string(api_error.details.message.unwrap_or(String::from("Unknown notification registration issue")))?}),
+                };
+                errors.push(notification_registration_error);
             }
+            _ => {}
         }
-        (error_chain_ids, json!(errors))
-    };
+    }
 
-    if error_chain_ids.is_empty() {
+    if errors.is_empty() {
         Ok(())
     } else {
-        Err(ApiError::new_from_message_with_debug(
-            format!(
-                "Push notification registration failed for chain IDs: {}",
-                error_chain_ids.join(", ")
-            ),
-            Some(error_body),
-        ))
+        let has_server_error = errors
+            .iter()
+            .any(|error| (500..600).contains(&error.status_code));
+        let error_chain_ids = errors.iter().map(|error| &error.chain_id).join(", ");
+        let json_error = errors.iter().map(|error| &error.error).collect::<Vec<_>>();
+
+        let error = ApiError {
+            // This is decoupled from the error collection so it is assuming that any value in [errors]
+            // is between 400 and 600. If server errors are found we return 500. Else we return 400
+            status: if has_server_error { 500 } else { 400 },
+            details: ErrorDetails {
+                code: 1337,
+                message: Some(format!(
+                    "Push notification registration failed for chain IDs: {}",
+                    error_chain_ids
+                )),
+                arguments: None,
+                debug: Some(json!(json_error)),
+            },
+        };
+        Err(error)
     }
 }
 

--- a/src/routes/notifications/tests/routes.rs
+++ b/src/routes/notifications/tests/routes.rs
@@ -236,7 +236,7 @@ async fn post_notification_success() {
 }
 
 #[rocket::async_test]
-async fn post_notification_error() {
+async fn post_notification_client_error() {
     let safe_address = "0x4cb09344de5bCCD45F045c5Defa0E0452869FF0f";
     let expected_error = ErrorDetails {
         code: 1337,
@@ -376,5 +376,112 @@ async fn post_notification_error() {
     let actual = serde_json::from_str::<ErrorDetails>(&error_body).unwrap();
 
     assert_eq!(Status::BadRequest, actual_status);
+    assert_eq!(expected_error, actual);
+}
+
+#[rocket::async_test]
+async fn post_notification_server_and_client_errors() {
+    let mut mock_http_client = MockHttpClient::new();
+    let safe_address = "0x4cb09344de5bCCD45F045c5Defa0E0452869FF0f";
+    // Mock /v1/chains/
+    let mut polygon_chain_request = Request::new(config_uri!("/v1/chains/{}/", 137));
+    polygon_chain_request.timeout(Duration::from_millis(chain_info_request_timeout()));
+    mock_http_client
+        .expect_get()
+        .with(eq(polygon_chain_request))
+        .times(1)
+        .return_once(move |_| {
+            Ok(Response {
+                status_code: 200,
+                body: String::from(crate::tests::json::CHAIN_INFO_POLYGON),
+            })
+        });
+    // Request Payload
+    let request = NotificationRegistrationRequest {
+        device_data: DeviceData {
+            uuid: None,
+            cloud_messaging_token: "cloud_messaging_token".to_string(),
+            build_number: "build_number".to_string(),
+            bundle: "bundle".to_string(),
+            device_type: DeviceType::Android,
+            version: "version".to_string(),
+            timestamp: None,
+        },
+        safe_registrations: vec![
+            SafeRegistration {
+                chain_id: "137".to_string(),
+                safes: vec!["0x0".to_string()],
+                signatures: vec!["signature".to_string()],
+            },
+            SafeRegistration {
+                chain_id: "137".to_string(),
+                safes: vec![safe_address.to_string()],
+                signatures: vec!["signature".to_string()],
+            },
+        ],
+    };
+    // POST request with first payload – returns a 400
+    let polygon_backend_request_0 =
+        build_backend_request(&request.device_data, &request.safe_registrations[0]);
+    let mut post_request_polygon_0 = Request::new(String::from(
+        "https://safe-transaction-polygon.staging.gnosisdev.com/api/v1/notifications/devices/",
+    ));
+    post_request_polygon_0.body(Some(
+        serde_json::to_string(&polygon_backend_request_0).unwrap(),
+    ));
+    mock_http_client
+        .expect_post()
+        .times(1)
+        .with(eq(post_request_polygon_0))
+        .return_once(move |_| {
+            Err(ApiError::new_from_message_with_code(
+                400,
+                "{ \"test\" : \"Some client error\"}".to_string(),
+            ))
+        });
+    // POST request with first payload – returns a 500
+    let polygon_backend_request_1 =
+        build_backend_request(&request.device_data, &request.safe_registrations[1]);
+    let mut post_request_polygon_1 = Request::new(String::from(
+        "https://safe-transaction-polygon.staging.gnosisdev.com/api/v1/notifications/devices/",
+    ));
+    post_request_polygon_1.body(Some(
+        serde_json::to_string(&polygon_backend_request_1).unwrap(),
+    ));
+    mock_http_client
+        .expect_post()
+        .times(1)
+        .with(eq(post_request_polygon_1))
+        .return_once(move |_| {
+            Err(ApiError::new_from_message_with_code(
+                500,
+                "{ \"test\" : \"Some server error\"}".to_string(),
+            ))
+        });
+
+    // Test execution
+    let client = Client::tracked(setup_rocket(
+        mock_http_client,
+        routes![super::super::routes::post_notification_registration],
+    ))
+    .await
+    .expect("valid rocket instance");
+    let request = client
+        .post("/v1/register/notifications")
+        .body(&serde_json::to_string(&request).unwrap())
+        .header(Header::new("Host", "test.gnosis.io"))
+        .header(ContentType::JSON);
+    let response = request.dispatch().await;
+    let actual_status = response.status();
+    let error_body = response.into_string().await.unwrap();
+    let actual = serde_json::from_str::<ErrorDetails>(&error_body).unwrap();
+
+    let expected_error = ErrorDetails {
+        code: 1337,
+        message: Some("Push notification registration failed for chain IDs: 137, 137".to_string()),
+        arguments: None,
+        debug: serde_json::from_str("[ {\"137\" : { \"test\" : \"Some client error\"}}, {\"137\" : { \"test\" : \"Some server error\"}}]").ok(),
+    };
+    assert_eq!(Status::InternalServerError, actual_status);
     assert_eq!(expected_error, actual);
 }

--- a/src/routes/notifications/tests/routes.rs
+++ b/src/routes/notifications/tests/routes.rs
@@ -375,6 +375,6 @@ async fn post_notification_error() {
     let error_body = response.into_string().await.unwrap();
     let actual = serde_json::from_str::<ErrorDetails>(&error_body).unwrap();
 
-    assert_eq!(Status::InternalServerError, actual_status);
+    assert_eq!(Status::BadRequest, actual_status);
     assert_eq!(expected_error, actual);
 }


### PR DESCRIPTION
Closes #793 

- Return `500` if any server error is found while posting to `/v1/notifications/devices/`
- If no server errors are found and client errors are present `4XX`, return `400`