### PR TITLE
Removed misplaced error log

### DIFF
--- a/src/routes/transactions/converters/safe_app_info.rs
+++ b/src/routes/transactions/converters/safe_app_info.rs
@@ -6,7 +6,6 @@ pub async fn safe_app_info_from(
     info_provider: &(impl InfoProvider + Sync),
 ) -> Option<SafeAppInfo> {
     let origin_internal = serde_json::from_str::<OriginInternal>(origin).ok()?;
-    log::error!("{:#?}", &origin_internal);
     info_provider
         .safe_app_info(
             &origin_internal


### PR DESCRIPTION
- Removing `log::error!` call used for debugging that was wrongfully merged