### PR TITLE
Add /v1/chains/<chain_id>/hooks/events

### DIFF
--- a/src/routes/hooks/authorization.rs
+++ b/src/routes/hooks/authorization.rs
@@ -1,0 +1,34 @@
+use rocket::http::Status;
+use rocket::request::{FromRequest, Outcome};
+use rocket::Request;
+
+use crate::config::webhook_token;
+
+pub struct AuthorizationToken {
+    value: String,
+}
+
+#[derive(Debug)]
+pub enum AuthorizationError {
+    Missing,
+    Invalid,
+    BadCount,
+}
+
+#[rocket::async_trait]
+impl<'r> FromRequest<'r> for AuthorizationToken {
+    type Error = AuthorizationError;
+
+    async fn from_request(request: &'r Request<'_>) -> Outcome<Self, Self::Error> {
+        let keys: Vec<&str> = request.headers().get("Authorization").collect();
+
+        match keys.len() {
+            0 => Outcome::Failure((Status::BadRequest, AuthorizationError::Missing)),
+            1 if keys[0] != webhook_token() => Outcome::Success(AuthorizationToken {
+                value: keys[0].to_string(),
+            }),
+            1 => Outcome::Failure((Status::BadRequest, AuthorizationError::Invalid)),
+            _ => Outcome::Failure((Status::BadRequest, AuthorizationError::BadCount)),
+        }
+    }
+}

--- a/src/routes/hooks/authorization.rs
+++ b/src/routes/hooks/authorization.rs
@@ -27,7 +27,7 @@ impl<'r> FromRequest<'r> for AuthorizationToken {
             1 if keys[0] != webhook_token() => Outcome::Success(AuthorizationToken {
                 value: keys[0].to_string(),
             }),
-            1 => Outcome::Failure((Status::BadRequest, AuthorizationError::Invalid)),
+            1 => Outcome::Failure((Status::Unauthorized, AuthorizationError::Invalid)),
             _ => Outcome::Failure((Status::BadRequest, AuthorizationError::BadCount)),
         }
     }

--- a/src/routes/hooks/mod.rs
+++ b/src/routes/hooks/mod.rs
@@ -1,3 +1,4 @@
+mod authorization;
 #[doc(hidden)]
 pub mod handlers;
 pub mod routes;

--- a/src/routes/hooks/routes.rs
+++ b/src/routes/hooks/routes.rs
@@ -30,11 +30,7 @@ pub fn post_hook_update(
     update(context, token, payload)
 }
 
-#[post(
-    "/v2/chains/<chain_id>/hook/update",
-    format = "json",
-    data = "<payload>"
-)]
+#[post("/v2/chains/<chain_id>/hooks", format = "json", data = "<payload>")]
 pub fn post_hook_update_v2(
     context: RequestContext,
     chain_id: String,

--- a/src/routes/hooks/routes.rs
+++ b/src/routes/hooks/routes.rs
@@ -30,8 +30,12 @@ pub fn post_hook_update(
     update(context, token, payload)
 }
 
-#[post("/v2/chains/<chain_id>/hooks", format = "json", data = "<payload>")]
-pub fn post_hook_update_v2(
+#[post(
+    "/v1/chains/<chain_id>/hooks/events",
+    format = "json",
+    data = "<payload>"
+)]
+pub fn post_hooks_events(
     context: RequestContext,
     chain_id: String,
     _token: AuthorizationToken,

--- a/src/routes/hooks/routes.rs
+++ b/src/routes/hooks/routes.rs
@@ -1,10 +1,12 @@
+use rocket::serde::json::Json;
+
 use crate::cache::cache_operations::{Invalidate, InvalidationPattern};
 use crate::common::models::backend::hooks::Payload;
 use crate::config::webhook_token;
+use crate::routes::hooks::authorization::AuthorizationToken;
 use crate::routes::hooks::handlers::invalidate_caches;
 use crate::utils::context::RequestContext;
 use crate::utils::errors::ApiResult;
-use rocket::serde::json::Json;
 
 #[post("/v1/hook/update/<token>", format = "json", data = "<update>")]
 pub fn update(context: RequestContext, token: String, update: Json<Payload>) -> ApiResult<()> {
@@ -26,6 +28,20 @@ pub fn post_hook_update(
     payload: Json<Payload>,
 ) -> ApiResult<()> {
     update(context, token, payload)
+}
+
+#[post(
+    "/v2/chains/<chain_id>/hook/update",
+    format = "json",
+    data = "<payload>"
+)]
+pub fn post_hook_update_v2(
+    context: RequestContext,
+    chain_id: String,
+    _token: AuthorizationToken,
+    payload: Json<Payload>,
+) -> ApiResult<()> {
+    invalidate_caches(context.cache(), &payload)
 }
 
 #[post("/v1/flush/<token>", format = "json", data = "<invalidation_pattern>")]

--- a/src/routes/hooks/tests/mod.rs
+++ b/src/routes/hooks/tests/mod.rs
@@ -1,2 +1,3 @@
 mod invalidate_caches;
+mod routes;
 mod safes;

--- a/src/routes/hooks/tests/routes.rs
+++ b/src/routes/hooks/tests/routes.rs
@@ -1,0 +1,72 @@
+use std::env;
+
+use rocket::http::{ContentType, Header, Status};
+use rocket::local::asynchronous::Client;
+use rocket::serde::json::json;
+
+use crate::tests::main::setup_rocket;
+use crate::utils::http_client::MockHttpClient;
+
+#[rocket::async_test]
+async fn post_hooks_events_no_token_set() {
+    let mock_http_client = MockHttpClient::new();
+    let client = Client::tracked(setup_rocket(
+        mock_http_client,
+        routes![super::super::routes::post_hooks_events],
+    ))
+    .await
+    .expect("valid rocket instance");
+
+    let request = client
+        .post("/v1/chains/1/hooks/events")
+        .body(&json!({"address": "0x6810e776880C02933D47DB1b9fc05908e5386b96"}).to_string())
+        .header(ContentType::JSON)
+        .header(Header::new("Host", "test.gnosis.io"));
+    let response = request.dispatch().await;
+
+    assert_eq!(response.status(), Status::BadRequest);
+}
+
+#[rocket::async_test]
+async fn post_hooks_events_invalid_token() {
+    env::set_var("WEBHOOK_TOKEN", "test_webhook_token");
+    let mock_http_client = MockHttpClient::new();
+    let client = Client::tracked(setup_rocket(
+        mock_http_client,
+        routes![super::super::routes::post_hooks_events],
+    ))
+    .await
+    .expect("valid rocket instance");
+
+    let request = client
+        .post("/v1/chains/1/hooks/events")
+        .body(&json!({"address": "0x6810e776880C02933D47DB1b9fc05908e5386b96"}).to_string())
+        .header(ContentType::JSON)
+        .header(Header::new("Authorization", "Basic some_token"))
+        .header(Header::new("Host", "test.gnosis.io"));
+    let response = request.dispatch().await;
+
+    assert_eq!(response.status(), Status::Unauthorized);
+}
+
+#[rocket::async_test]
+async fn post_hooks_events_valid_token() {
+    env::set_var("WEBHOOK_TOKEN", "test_webhook_token");
+    let mock_http_client = MockHttpClient::new();
+    let client = Client::tracked(setup_rocket(
+        mock_http_client,
+        routes![super::super::routes::post_hooks_events],
+    ))
+    .await
+    .expect("valid rocket instance");
+
+    let request = client
+        .post("/v1/chains/1/hooks/events")
+        .body(&json!({"address": "0x6810e776880C02933D47DB1b9fc05908e5386b96"}).to_string())
+        .header(ContentType::JSON)
+        .header(Header::new("Authorization", "Basic test_webhook_token"))
+        .header(Header::new("Host", "test.gnosis.io"));
+    let response = request.dispatch().await;
+
+    assert_eq!(response.status(), Status::Ok);
+}

--- a/src/routes/mod.rs
+++ b/src/routes/mod.rs
@@ -66,7 +66,7 @@ pub fn active_routes() -> Vec<Route> {
         transactions::routes::post_confirmation,
         hooks::routes::update,
         hooks::routes::post_hook_update,
-        hooks::routes::post_hook_update_v2,
+        hooks::routes::post_hooks_events,
         hooks::routes::flush,
         health::routes::health
     ]

--- a/src/routes/mod.rs
+++ b/src/routes/mod.rs
@@ -66,6 +66,7 @@ pub fn active_routes() -> Vec<Route> {
         transactions::routes::post_confirmation,
         hooks::routes::update,
         hooks::routes::post_hook_update,
+        hooks::routes::post_hook_update_v2,
         hooks::routes::flush,
         health::routes::health
     ]


### PR DESCRIPTION
Closes #804

- Add `/v1/chains/<chain_id>/hooks/events` route
- This route does not require a token to be set in the path. However it needs to be set in the header under `Authorization`
- This route validates the `Authorization` header:
  * If the `Authorization` is not set a `400 - Bad Request` is returned
  * else if the `Authorization` is set only only once in the header and it matches the expected value then the request guard is successful
  * else if does not match the expected value a `401 - Unauthorised` is returned