### PR TITLE
Map 404 to null when verifying trusted delegate

### DIFF
--- a/src/routes/transactions/converters/details.rs
+++ b/src/routes/transactions/converters/details.rs
@@ -181,7 +181,16 @@ pub async fn is_trusted_delegate_call(
     info_provider: &(impl InfoProvider + Sync),
 ) -> ApiResult<Option<bool>> {
     if operation == &Operation::DELEGATE {
-        let contract_info = info_provider.contract_info(to).await?;
+        let contract_info = info_provider.contract_info(to).await;
+        let contract_info = match contract_info {
+            Ok(contract_info) => contract_info,
+            Err(api_error) => {
+                return match api_error.status {
+                    404 => Ok(None),
+                    _ => Err(api_error),
+                };
+            }
+        };
 
         let has_nested_delegate_calls = !data_decoded
             .as_ref()


### PR DESCRIPTION
When the contract info is not found (`404`) the response of the `/v1/chains/<chain_id>/transactions/<tx_id>` route was mapped to a `404`

This changes the mapping of that `404` to a successful case (`null`) and the transaction data is therefore returned and the response is successful (`200`)