### PR TITLE
Add /v2/flush

### DIFF
--- a/src/routes/hooks/routes.rs
+++ b/src/routes/hooks/routes.rs
@@ -56,3 +56,13 @@ pub fn flush(
     Invalidate::new(invalidation_pattern.0, context.cache()).execute();
     Ok(())
 }
+
+#[post("/v1/flush/events", format = "json", data = "<invalidation_pattern>")]
+pub fn post_flush_events(
+    context: RequestContext,
+    _token: AuthorizationToken,
+    invalidation_pattern: Json<InvalidationPattern>,
+) -> ApiResult<()> {
+    Invalidate::new(invalidation_pattern.0, context.cache()).execute();
+    Ok(())
+}

--- a/src/routes/hooks/routes.rs
+++ b/src/routes/hooks/routes.rs
@@ -57,7 +57,7 @@ pub fn flush(
     Ok(())
 }
 
-#[post("/v1/flush/events", format = "json", data = "<invalidation_pattern>")]
+#[post("/v2/flush", format = "json", data = "<invalidation_pattern>")]
 pub fn post_flush_events(
     context: RequestContext,
     _token: AuthorizationToken,

--- a/src/routes/hooks/tests/routes.rs
+++ b/src/routes/hooks/tests/routes.rs
@@ -82,7 +82,7 @@ async fn post_flush_events_no_token_set() {
     .expect("valid rocket instance");
 
     let request = client
-        .post("/v1/flush/events")
+        .post("/v2/flush")
         .header(ContentType::JSON)
         .header(Header::new("Host", "test.gnosis.io"));
     let response = request.dispatch().await;
@@ -102,7 +102,7 @@ async fn post_flush_events_invalid_token() {
     .expect("valid rocket instance");
 
     let request = client
-        .post("/v1/flush/events")
+        .post("/v2/flush")
         .header(ContentType::JSON)
         .header(Header::new("Host", "test.gnosis.io"))
         .header(Header::new("Authorization", "Basic some_token"));
@@ -123,7 +123,7 @@ async fn post_flush_events_valid_token() {
     .expect("valid rocket instance");
 
     let request = client
-        .post("/v1/flush/events")
+        .post("/v2/flush")
         .body(&json!({"invalidate": "Chains"}).to_string())
         .header(ContentType::JSON)
         .header(Header::new("Host", "test.gnosis.io"))

--- a/src/routes/mod.rs
+++ b/src/routes/mod.rs
@@ -67,6 +67,7 @@ pub fn active_routes() -> Vec<Route> {
         hooks::routes::update,
         hooks::routes::post_hook_update,
         hooks::routes::post_hooks_events,
+        hooks::routes::post_flush_events,
         hooks::routes::flush,
         health::routes::health
     ]


### PR DESCRIPTION
- Add a new route `/v2/flush` which requires an `Authorization` header to be set (with the value `Basic <WEBHOOK_TOKEN>`)