### PR TITLE
Remove unused extern crates

### DIFF
--- a/src/main.rs
+++ b/src/main.rs
@@ -1,10 +1,6 @@
 #![deny(unused_must_use)]
 #![deny(rustdoc::broken_intra_doc_links)]
 
-extern crate dotenv;
-extern crate log;
-extern crate semver;
-
 #[macro_use]
 extern crate rocket;
 

--- a/src/routes/about/handlers.rs
+++ b/src/routes/about/handlers.rs
@@ -1,5 +1,3 @@
-extern crate reqwest;
-
 use crate::config::{build_number, version};
 use crate::providers::info::{DefaultInfoProvider, InfoProvider};
 use crate::routes::about::models::{About, ChainAbout};

--- a/src/routes/about/tests/routes.rs
+++ b/src/routes/about/tests/routes.rs
@@ -1,5 +1,3 @@
-extern crate dotenv;
-
 use core::time::Duration;
 use std::env;
 

--- a/src/routes/mod.rs
+++ b/src/routes/mod.rs
@@ -1,5 +1,3 @@
-extern crate rocket;
-
 use rocket::response::Redirect;
 use rocket::serde::json::{json, Value};
 use rocket::{Catcher, Route};

--- a/src/routes/transactions/converters/details.rs
+++ b/src/routes/transactions/converters/details.rs
@@ -1,5 +1,3 @@
-extern crate chrono;
-
 use crate::common::models::addresses::AddressEx;
 use crate::common::models::backend::transactions::{ModuleTransaction, MultisigTransaction};
 use crate::common::models::data_decoded::{DataDecoded, Operation};

--- a/src/routes/transactions/converters/mod.rs
+++ b/src/routes/transactions/converters/mod.rs
@@ -1,5 +1,3 @@
-extern crate chrono;
-
 pub mod details;
 pub mod safe_app_info;
 pub mod summary;

--- a/src/routes/transactions/converters/summary.rs
+++ b/src/routes/transactions/converters/summary.rs
@@ -1,5 +1,3 @@
-extern crate chrono;
-
 use crate::common::models::backend::transactions::{
     CreationTransaction, EthereumTransaction, ModuleTransaction, MultisigTransaction, Transaction,
 };

--- a/src/routes/transactions/converters/tests/is_cancellation.rs
+++ b/src/routes/transactions/converters/tests/is_cancellation.rs
@@ -1,6 +1,6 @@
-use super::super::chrono::Utc;
 use crate::common::models::backend::transactions::{MultisigTransaction, SafeTransaction};
 use crate::common::models::data_decoded::Operation;
+use chrono::Utc;
 
 #[test]
 fn is_cancellation_result_true() {

--- a/src/routes/transactions/handlers/details.rs
+++ b/src/routes/transactions/handlers/details.rs
@@ -1,5 +1,3 @@
-extern crate reqwest;
-
 use crate::cache::cache_operations::RequestCached;
 use crate::common::models::backend::transactions::{ModuleTransaction, MultisigTransaction};
 use crate::common::models::backend::transfers::Transfer;

--- a/src/routes/transactions/handlers/history.rs
+++ b/src/routes/transactions/handlers/history.rs
@@ -1,5 +1,3 @@
-extern crate reqwest;
-
 use crate::cache::cache_operations::RequestCached;
 use crate::common::models::backend::transactions::{CreationTransaction, Transaction};
 use crate::common::models::page::{Page, PageMetadata};

--- a/src/routes/transactions/tests/routes.rs
+++ b/src/routes/transactions/tests/routes.rs
@@ -1,5 +1,3 @@
-extern crate dotenv;
-
 use crate::common::models::page::Page;
 use crate::config::{
     chain_info_request_timeout, contract_info_request_timeout, safe_info_request_timeout,

--- a/src/tests/main.rs
+++ b/src/tests/main.rs
@@ -1,5 +1,3 @@
-extern crate dotenv;
-
 use crate::cache::{Cache, MockCache};
 use crate::create_service_cache;
 use crate::utils::http_client::{HttpClient, MockHttpClient};


### PR DESCRIPTION
- Some `extern crate` are no longer required
- Additionally, a more idiomatic way was introduced in Rust 2018 – https://doc.rust-lang.org/edition-guide/rust-2018/path-changes.html#no-more-extern-crate (adding it to `Cargo.toml` should be sufficient in most scenarios) 