### PR TITLE
Delete Procfile

### DIFF
--- a/Procfile
+++ b/Procfile
@@ -1,1 +1,0 @@
-web: ROCKET_PORT=$PORT target/release/safe-client-gateway


### PR DESCRIPTION
- Delete unused `Procfile`
- It was being used when Heroku support was being added