### PR TITLE
Bump rust from 1.58.0 to 1.59.0

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,6 +1,6 @@
 # Build Image
 # match with version in rust-toolchain.toml file
-FROM rust:1.58.0-slim-buster as builder
+FROM rust:1.59.0-slim-buster as builder
 
 RUN set -ex; \ 
   apt-get update; \

--- a/rust-toolchain.toml
+++ b/rust-toolchain.toml
@@ -1,3 +1,3 @@
 [toolchain]
 # match with version in DockerFile
-channel = "1.58.0"
+channel = "1.59.0"


### PR DESCRIPTION
Changelog: https://blog.rust-lang.org/2022/02/24/Rust-1.59.0.html