### PR TITLE
New `SetGuard` and `DeleteGuard` variants added to `SettingsInfo`

### DIFF
--- a/src/common/converters/data_decoded.rs
+++ b/src/common/converters/data_decoded.rs
@@ -87,7 +87,6 @@ impl DataDecoded {
                     SettingsInfo::DeleteGuard
                 };
                 Some(settings_info)
-                // gas_token == "0x0000000000000000000000000000000000000000"
             }
             _ => None,
         }

--- a/src/common/converters/data_decoded.rs
+++ b/src/common/converters/data_decoded.rs
@@ -8,7 +8,8 @@ use crate::providers::info::InfoProvider;
 use crate::routes::transactions::models::SettingsInfo;
 use crate::utils::{
     ADD_OWNER_WITH_THRESHOLD, CHANGE_MASTER_COPY, CHANGE_THRESHOLD, DISABLE_MODULE, ENABLE_MODULE,
-    MULTI_SEND, MULTI_SEND_TRANSACTIONS_PARAM, REMOVE_OWNER, SET_FALLBACK_HANDLER, SWAP_OWNER,
+    MULTI_SEND, MULTI_SEND_TRANSACTIONS_PARAM, REMOVE_OWNER, SET_FALLBACK_HANDLER, SET_GUARD,
+    SWAP_OWNER,
 };
 use std::collections::HashMap;
 
@@ -75,6 +76,19 @@ impl DataDecoded {
             CHANGE_THRESHOLD => Some(SettingsInfo::ChangeThreshold {
                 threshold: self.get_parameter_single_value_at(0)?.parse().ok()?,
             }),
+            SET_GUARD => {
+                let guard = self.get_parameter_single_value_at(0)?;
+                let settings_info = if guard != "0x0000000000000000000000000000000000000000" {
+                    let guard = info_provider
+                        .address_ex_from_contracts_or_default(&guard)
+                        .await;
+                    SettingsInfo::SetGuard { guard }
+                } else {
+                    SettingsInfo::DeleteGuard
+                };
+                Some(settings_info)
+                // gas_token == "0x0000000000000000000000000000000000000000"
+            }
             _ => None,
         }
     }

--- a/src/routes/transactions/models/mod.rs
+++ b/src/routes/transactions/models/mod.rs
@@ -146,6 +146,10 @@ pub enum SettingsInfo {
     EnableModule { module: AddressEx },
     #[serde(rename_all = "camelCase")]
     DisableModule { module: AddressEx },
+    #[serde(rename_all = "camelCase")]
+    SetGuard { guard: AddressEx },
+    #[serde(rename_all = "camelCase")]
+    DeleteGuard,
 }
 
 #[derive(Serialize, Debug, PartialEq)]

--- a/src/tests/json/commons/data_decoded_delete_guard.json
+++ b/src/tests/json/commons/data_decoded_delete_guard.json
@@ -1,0 +1,10 @@
+{
+  "method": "setGuard",
+  "parameters": [
+    {
+      "name": "guard",
+      "type": "address",
+      "value": "0x0000000000000000000000000000000000000000"
+    }
+  ]
+}

--- a/src/tests/json/commons/data_decoded_set_guard.json
+++ b/src/tests/json/commons/data_decoded_set_guard.json
@@ -1,0 +1,10 @@
+{
+  "method": "setGuard",
+  "parameters": [
+    {
+      "name": "guard",
+      "type": "address",
+      "value": "0xf2565317F3Ae8Ae9EA98E9Fe1e7FADC77F823cbD"
+    }
+  ]
+}

--- a/src/tests/json/mod.rs
+++ b/src/tests/json/mod.rs
@@ -123,6 +123,8 @@ pub const DOCTORED_DATA_DECODED_NESTED_MULTI_SENDS: &str =
     include_str!("commons/DOCTORED_data_decoded_nested_multi_sends.json");
 pub const DOCTORED_DATA_DECODED_MULTI_SEND_NESTED_DELEGATE: &str =
     include_str!("commons/DOCTORED_data_decoded_multi_send_nested_delegate.json");
+pub const DATA_DECODED_SET_GUARD: &str = include_str!("commons/data_decoded_set_guard.json");
+pub const DATA_DECODED_DELETE_GUARD: &str = include_str!("commons/data_decoded_delete_guard.json");
 
 pub const BALANCE_ETHER: &str = include_str!("balances/balance_ether.json");
 pub const BALANCE_COMPOUND_ETHER: &str = include_str!("balances/balance_compound_ether.json");

--- a/src/utils/mod.rs
+++ b/src/utils/mod.rs
@@ -32,6 +32,7 @@ pub const CHANGE_THRESHOLD: &'static str = "changeThreshold";
 pub const CHANGE_MASTER_COPY: &'static str = "changeMasterCopy";
 pub const ENABLE_MODULE: &'static str = "enableModule";
 pub const DISABLE_MODULE: &'static str = "disableModule";
+pub const SET_GUARD: &'static str = "setGuard";
 
 pub const MULTI_SEND: &'static str = "multiSend";
 pub const MULTI_SEND_TRANSACTIONS_PARAM: &'static str = "transactions";
@@ -45,6 +46,7 @@ pub const SETTINGS_CHANGE_METHODS: &[&str] = &[
     CHANGE_MASTER_COPY,
     ENABLE_MODULE,
     DISABLE_MODULE,
+    SET_GUARD,
 ];
 
 impl DataDecoded {


### PR DESCRIPTION
Closes #813 

Changes:
- Method name `setGuard` in `dataDecoded` is observed to be mapped to the new `SettingsInfo` variants
- `setGuard`'s guard address always comes in the parameter index `0` of `dataDecoded`
- `SetGuard { guard: AddressEx }` is returned when the address is different than `0x0....0`
- `DeleteGuard` is returned when the `setGuard` method is called with the `0x0....0` value
- These assumptions are documented as unit tests 