### PR TITLE
Extracted max size of request to tokens endpoint

### DIFF
--- a/src/config/mod.rs
+++ b/src/config/mod.rs
@@ -169,6 +169,10 @@ pub fn redis_scan_count() -> usize {
     env_with_default("REDIS_SCAN_COUNT", 300)
 }
 
+pub fn token_cache_size_count() -> usize {
+    env_with_default("TOKEN_CACHE_SIZE_COUNT", 20000)
+}
+
 pub fn feature_flag_nested_decoding() -> bool {
     env_with_default("FEATURE_FLAG_NESTED_DECODING", true)
 }

--- a/src/config/tests/mod.rs
+++ b/src/config/tests/mod.rs
@@ -78,6 +78,11 @@ fn build_usize_test_cases() -> Vec<USizeEnvValue> {
             env_key: String::from("TX_QUEUED_CACHE_DURATION"),
             generator: Box::new(super::tx_queued_cache_duration),
         },
+        USizeEnvValue {
+            expected_default: super::token_cache_size_count(),
+            env_key: String::from("TOKEN_CACHE_SIZE_COUNT"),
+            generator: Box::new(super::token_cache_size_count),
+        },
     ]
 }
 

--- a/src/providers/info.rs
+++ b/src/providers/info.rs
@@ -9,7 +9,7 @@ use crate::config::{
     contract_info_request_timeout, default_request_timeout, long_error_duration,
     request_cache_duration, safe_app_info_request_timeout, safe_app_manifest_cache_duration,
     safe_info_cache_duration, safe_info_request_timeout, short_error_duration,
-    token_info_cache_duration, token_info_request_timeout,
+    token_cache_size_count, token_info_cache_duration, token_info_request_timeout,
 };
 use crate::providers::address_info::ContractInfo;
 use crate::utils::context::RequestContext;
@@ -260,7 +260,8 @@ impl DefaultInfoProvider<'_> {
     }
 
     async fn populate_token_cache(&self) -> ApiResult<()> {
-        let url = core_uri!(self, "/v1/tokens/?limit=10000")?;
+        let token_cache_size_count = token_cache_size_count();
+        let url = core_uri!(self, "/v1/tokens/?limit={}", token_cache_size_count)?;
         let request = {
             let mut request = Request::new(url);
             request.timeout(Duration::from_millis(token_info_request_timeout()));

--- a/src/providers/tests/info.rs
+++ b/src/providers/tests/info.rs
@@ -224,7 +224,7 @@ async fn default_info_provider_token_info() {
         });
 
     let mut token_request = Request::new(String::from(
-        "https://safe-transaction.rinkeby.staging.gnosisdev.com/api/v1/tokens/?limit=10000",
+        "https://safe-transaction.rinkeby.staging.gnosisdev.com/api/v1/tokens/?limit=20000",
     ));
     token_request.timeout(Duration::from_millis(token_info_request_timeout()));
     let page_tokens: Page<TokenInfo> = Page {
@@ -281,7 +281,7 @@ async fn default_info_provider_token_info_request_failure() {
         });
 
     let mut token_request = Request::new(String::from(
-        "https://safe-transaction.rinkeby.staging.gnosisdev.com/api/v1/tokens/?limit=10000",
+        "https://safe-transaction.rinkeby.staging.gnosisdev.com/api/v1/tokens/?limit=20000",
     ));
     token_request.timeout(Duration::from_millis(token_info_request_timeout()));
 
@@ -334,7 +334,7 @@ async fn default_info_provider_token_info_not_found_in_cache() {
         });
 
     let mut token_request = Request::new(String::from(
-        "https://safe-transaction.rinkeby.staging.gnosisdev.com/api/v1/tokens/?limit=10000",
+        "https://safe-transaction.rinkeby.staging.gnosisdev.com/api/v1/tokens/?limit=20000",
     ));
     token_request.timeout(Duration::from_millis(token_info_request_timeout()));
     let page_tokens: Page<TokenInfo> = Page {

--- a/src/routes/transactions/tests/routes.rs
+++ b/src/routes/transactions/tests/routes.rs
@@ -84,7 +84,7 @@ async fn post_confirmation_success() {
 
         // Transfer TokenInfo
         let mut token_request = Request::new(String::from(
-            "https://safe-transaction.rinkeby.staging.gnosisdev.com/api/v1/tokens/?limit=10000",
+            "https://safe-transaction.rinkeby.staging.gnosisdev.com/api/v1/tokens/?limit=20000",
         ));
         token_request.timeout(Duration::from_millis(token_info_request_timeout()));
         let page_tokens: Page<TokenInfo> = Page {


### PR DESCRIPTION
Closes #828 

- Introduction of `TOKEN_CACHE_SIZE_COUNT` to limit the count of tokens requested to warm up our cache
- Set the default value to `20,000`
- Adjusted tests