### PR TITLE
Remove auth header from /owners/<address>/safes

### DIFF
--- a/src/config/mod.rs
+++ b/src/config/mod.rs
@@ -28,14 +28,6 @@ pub fn webhook_token() -> String {
     env::var("WEBHOOK_TOKEN").expect("WEBHOOK_TOKEN missing in env")
 }
 
-pub fn transaction_service_auth_token() -> String {
-    let token = env::var("TRANSACTION_SERVICE_AUTH_TOKEN").unwrap_or_else(|_| {
-        log::warn!("TRANSACTION_SERVICE_AUTH_TOKEN missing in env");
-        String::new()
-    });
-    format!("Token {}", token)
-}
-
 pub fn scheme() -> String {
     env_with_default("SCHEME", "https".into())
 }

--- a/src/routes/safes/handlers/safes.rs
+++ b/src/routes/safes/handlers/safes.rs
@@ -2,9 +2,7 @@ use crate::cache::cache_operations::RequestCached;
 use crate::common::models::backend::transactions::{MultisigTransaction, Transaction};
 use crate::common::models::backend::transfers::Transfer;
 use crate::common::models::page::{Page, SafeList};
-use crate::config::{
-    owners_for_safes_cache_duration, transaction_request_timeout, transaction_service_auth_token,
-};
+use crate::config::{owners_for_safes_cache_duration, transaction_request_timeout};
 use crate::providers::info::{DefaultInfoProvider, InfoProvider};
 use crate::routes::safes::models::{SafeLastChanges, SafeState};
 use crate::utils::context::RequestContext;
@@ -153,7 +151,6 @@ pub async fn get_owners_for_safe(
     let url = core_uri!(info_provider, "/v1/owners/{}/safes/", owner_address)?;
     let body = RequestCached::new_from_context(url, context)
         .cache_duration(owners_for_safes_cache_duration())
-        .add_header(("Authorization", &transaction_service_auth_token()))
         .execute()
         .await?;
 

--- a/src/routes/safes/tests/routes.rs
+++ b/src/routes/safes/tests/routes.rs
@@ -263,9 +263,6 @@ async fn get_owners() {
         "https://safe-transaction.rinkeby.staging.gnosisdev.com/api/v1/owners/{}/safes/",
         &safe_address
     ));
-    let auth_token = "some_other_random_token";
-    env::set_var("TRANSACTION_SERVICE_AUTH_TOKEN", &auth_token);
-    safe_request.add_header(("Authorization", &format!("Token {}", &auth_token)));
     mock_http_client
         .expect_get()
         .times(1)
@@ -325,9 +322,6 @@ async fn get_owners_not_found() {
         "https://safe-transaction.rinkeby.staging.gnosisdev.com/api/v1/owners/{}/safes/",
         &safe_address
     ));
-    let auth_token = "some_other_random_token";
-    env::set_var("TRANSACTION_SERVICE_AUTH_TOKEN", &auth_token);
-    safe_request.add_header(("Authorization", &format!("Token {}", &auth_token)));
     mock_http_client
         .expect_get()
         .times(1)


### PR DESCRIPTION
- Remove `Authorization` header from the `/owners/<address>/safes`
- If an `Authorization` header is provided then the Safe Transaction Service validated it even though it is not required for this endpoint