### PR TITLE
Fix query parameter builder

### DIFF
--- a/src/routes/transactions/handlers/commons.rs
+++ b/src/routes/transactions/handlers/commons.rs
@@ -18,15 +18,17 @@ where
     D: DeserializeOwned,
 {
     let mut full_url = String::from(url);
+    full_url.push_str("?");
+    page_meta.as_ref().map(|page_meta| {
+        full_url.push_str("&");
+        full_url.push_str(&page_meta.to_url_string());
+    });
+
     let filters = filters.as_query_param();
     if !filters.is_empty() {
         full_url.push_str("&");
         full_url.push_str(&filters);
     }
-    page_meta.as_ref().map(|page_meta| {
-        full_url.push_str("&");
-        full_url.push_str(&page_meta.to_url_string());
-    });
     let body = RequestCached::new_from_context(full_url, context, ChainCache::from(chain_id))
         .request_timeout(request_timeout)
         .execute()

--- a/src/routes/transactions/handlers/tests/transfers.rs
+++ b/src/routes/transactions/handlers/tests/transfers.rs
@@ -32,7 +32,7 @@ pub async fn get_incoming_transfers_no_filters() {
         });
 
     let mut transfer_request = Request::new(format!(
-        "https://safe-transaction.rinkeby.staging.gnosisdev.com/api/v1/safes/{}/incoming-transfers/",
+        "https://safe-transaction.rinkeby.staging.gnosisdev.com/api/v1/safes/{}/incoming-transfers/?",
         &safe_address
     ));
     transfer_request.timeout(Duration::from_millis(transaction_request_timeout()));


### PR DESCRIPTION
- Fix the query parameter builder in `get_backend_page`
- It was adding query parameters without adding a `?` which results in an invalid URL
- Add page metadata first since it's always available as a query parameters (compared to the endpoint filters)

This solution is still not ideal. We should start using https://docs.rs/reqwest/latest/reqwest/struct.Url.html# in order to build valid URLs