### PR TITLE
Use config service to get safe app info

### DIFF
--- a/src/providers/tests/info.rs
+++ b/src/providers/tests/info.rs
@@ -478,6 +478,18 @@ async fn default_info_provider_safe_app_info() {
             })
         });
 
+    let config_service_request = Request::new(config_uri!("/v1/safe-apps/?url={}", &origin_url));
+    mock_http_client
+        .expect_get()
+        .times(1)
+        .with(eq(config_service_request))
+        .returning(move |_| {
+            Err(ApiError::from_http_response(&Response {
+                body: "".to_string(),
+                status_code: 0,
+            }))
+        });
+
     let context = RequestContext::setup_for_test(
         String::from(""),
         config_uri!(""),
@@ -522,6 +534,18 @@ async fn default_info_provider_safe_app_info_not_found() {
             Err(ApiError::from_http_response(&Response {
                 status_code: 404,
                 body: String::from("Not found"),
+            }))
+        });
+
+    let config_service_request = Request::new(config_uri!("/v1/safe-apps/?url={}", &origin_url));
+    mock_http_client
+        .expect_get()
+        .times(1)
+        .with(eq(config_service_request))
+        .returning(move |_| {
+            Err(ApiError::from_http_response(&Response {
+                body: "".to_string(),
+                status_code: 0,
             }))
         });
 

--- a/src/providers/tests/info.rs
+++ b/src/providers/tests/info.rs
@@ -510,6 +510,60 @@ async fn default_info_provider_safe_app_info() {
 }
 
 #[rocket::async_test]
+async fn default_info_provider_safe_app_info_from_safe_config() {
+    let origin_url = "https://test.app";
+    let cache_manager = create_cache_manager().await;
+    cache_manager
+        .cache_for_chain(ChainCache::Mainnet)
+        .invalidate_pattern("*")
+        .await;
+    cache_manager
+        .cache_for_chain(ChainCache::Other)
+        .invalidate_pattern("*")
+        .await;
+
+    let mut mock_http_client = MockHttpClient::new();
+    let mut safe_app_request = Request::new(format!("{}/manifest.json", &origin_url));
+    safe_app_request.timeout(Duration::from_millis(safe_app_info_request_timeout()));
+
+    mock_http_client
+        .expect_get()
+        .never()
+        .with(eq(safe_app_request));
+
+    let config_service_request = Request::new(config_uri!("/v1/safe-apps/?url={}", &origin_url));
+    mock_http_client
+        .expect_get()
+        .times(1)
+        .with(eq(config_service_request))
+        .returning(move |_| {
+            Ok(Response {
+                body: String::from(crate::tests::json::POLYGON_SAFE_APP_URL_QUERY),
+                status_code: 200,
+            })
+        });
+
+    let context = RequestContext::setup_for_test(
+        String::from(""),
+        config_uri!(""),
+        &(Arc::new(mock_http_client) as Arc<dyn HttpClient>),
+        &(Arc::new(cache_manager) as Arc<dyn RedisCacheManager>),
+    )
+    .await;
+
+    let expected = Ok(SafeAppInfo {
+        name: String::from("Test App"),
+        url: String::from("https://test.app"),
+        logo_uri: format!("{}/{}", "https://test.app", "logo.svg"),
+    });
+
+    let info_provider = DefaultInfoProvider::new("137", &context);
+    let actual = info_provider.safe_app_info(origin_url).await;
+
+    assert_eq!(expected, actual);
+}
+
+#[rocket::async_test]
 async fn default_info_provider_safe_app_info_not_found() {
     let origin_url = "https://app.uniswap.org";
     let cache_manager = create_cache_manager().await;

--- a/src/tests/json/mod.rs
+++ b/src/tests/json/mod.rs
@@ -150,6 +150,8 @@ pub const CHAIN_INFO_RINKEBY_ENABLED_FEATURES: &str =
     include_str!("chains/rinkeby_enabled_features.json");
 
 pub const POLYGON_SAFE_APPS: &str = include_str!("safe_apps/polygon_safe_apps.json");
+pub const POLYGON_SAFE_APP_URL_QUERY: &str =
+    include_str!("safe_apps/polygon_safe_app_url_query.json");
 pub const POLYGON_SAFE_APPS_WITH_TAGS: &str =
     include_str!("safe_apps/polygon_safe_apps_with_tags.json");
 pub const UNISWAP_SAFE_APP_MANIFEST: &str = include_str!("safe_apps/uniswap_manifest.json");

--- a/src/tests/json/safe_apps/polygon_safe_app_url_query.json
+++ b/src/tests/json/safe_apps/polygon_safe_app_url_query.json
@@ -1,0 +1,14 @@
+[
+  {
+    "id": 26,
+    "url": "https://test.app",
+    "name": "Test App",
+    "iconUrl": "https://test.app/logo.svg",
+    "description": "Some cool app",
+    "chainIds": [1, 137],
+    "provider": null,
+    "accessControl": {
+      "type": "NO_RESTRICTIONS"
+    }
+  }
+]


### PR DESCRIPTION
Closes https://github.com/safe-global/safe-client-gateway/issues/855

- Use the Safe Config Service to get information about a specific app using the `url` filter
- If the filter doesn't provide any results, or the result is an error, fallback to get information from the manifest