### PR TITLE
Add executed query param to MultisigFilters

### DIFF
--- a/src/routes/transactions/filters/multisig.rs
+++ b/src/routes/transactions/filters/multisig.rs
@@ -12,6 +12,7 @@ pub struct MultisigFilters {
     pub to: Option<String>,
     pub value: Option<String>,
     pub nonce: Option<String>,
+    pub executed: Option<String>,
 }
 
 impl QueryParam for MultisigFilters {
@@ -38,6 +39,10 @@ impl QueryParam for MultisigFilters {
             query_params.push_str(&format!("nonce={}&", nonce))
         }
 
+        if let Some(executed) = &self.executed {
+            query_params.push_str(&format!("executed={}&", executed))
+        }
+
         return query_params;
     }
 }
@@ -51,13 +56,15 @@ impl
             Option<String>,
             Option<String>,
             Option<String>,
+            Option<String>,
         ),
     > for MultisigFilters
 {
     type Target = MultisigFilters;
 
     fn from_uri_param(
-        (execution_date_gte, execution_date_lte, to, value, nonce): (
+        (execution_date_gte, execution_date_lte, to, value, nonce, executed): (
+            Option<String>,
             Option<String>,
             Option<String>,
             Option<String>,
@@ -71,6 +78,7 @@ impl
             to,
             value,
             nonce,
+            executed,
         }
     }
 }
@@ -81,6 +89,7 @@ impl UriDisplay<Query> for MultisigFilters {
         f.write_named_value("execution_date__lte", &self.execution_date_lte)?;
         f.write_named_value("to", &self.to)?;
         f.write_named_value("value", &self.value)?;
-        f.write_named_value("nonce", &self.nonce)
+        f.write_named_value("nonce", &self.nonce)?;
+        f.write_named_value("executed", &self.executed)
     }
 }

--- a/src/routes/transactions/filters/tests/mod.rs
+++ b/src/routes/transactions/filters/tests/mod.rs
@@ -81,6 +81,7 @@ pub fn multisig_filters() {
         to: Some(String::from("0x1230B3d59858296A31053C1b8562Ecf89A2f888b")),
         value: Some(String::from("100")),
         nonce: Some(String::from("50")),
+        executed: Some(String::from("true")),
     };
 
     let filter_none = MultisigFilters {
@@ -89,6 +90,7 @@ pub fn multisig_filters() {
         to: None,
         value: None,
         nonce: None,
+        executed: None,
     };
 
     let filter_only_to = MultisigFilters {
@@ -97,6 +99,7 @@ pub fn multisig_filters() {
         to: Some(String::from("0x1230B3d59858296A31053C1b8562Ecf89A2f888b")),
         value: None,
         nonce: None,
+        executed: None,
     };
 
     assert_eq!(
@@ -105,7 +108,8 @@ pub fn multisig_filters() {
         execution_date__lte=4321&\
     to=0x1230B3d59858296A31053C1b8562Ecf89A2f888b&\
     value=100&\
-    nonce=50&"
+    nonce=50&\
+    executed=true&"
     );
     assert_eq!(filter_none.as_query_param(), "");
     assert_eq!(

--- a/src/routes/transactions/handlers/multisig.rs
+++ b/src/routes/transactions/handlers/multisig.rs
@@ -111,7 +111,8 @@ fn build_cursor(
                         filters.execution_date_lte.to_owned(),
                         filters.to.to_owned(),
                         filters.value.to_owned(),
-                        filters.nonce.to_owned()
+                        filters.nonce.to_owned(),
+                        filters.executed.to_owned(),
                     )
                 )
             ),


### PR DESCRIPTION
- Adds `executed` query param to `MultisigFilters` – which is used in the endpoint `/v1/chains/<chain_id>/safes/<safe_address>/multisig-transactions`
- This was added so that on the client side, this endpoint can be filtered on the transactions already executed (history) and the queued transactions