### PR TITLE
Fix pagination default query

### DIFF
--- a/src/routes/transactions/handlers/commons.rs
+++ b/src/routes/transactions/handlers/commons.rs
@@ -11,7 +11,7 @@ pub async fn get_backend_page<D>(
     chain_id: &str,
     url: &str,
     request_timeout: u64,
-    page_meta: &Option<PageMetadata>,
+    page_meta: &PageMetadata,
     filters: &(impl QueryParam + std::fmt::Debug),
 ) -> ApiResult<Page<D>>
 where
@@ -19,10 +19,7 @@ where
 {
     let mut full_url = String::from(url);
     full_url.push_str("?");
-    page_meta.as_ref().map(|page_meta| {
-        full_url.push_str("&");
-        full_url.push_str(&page_meta.to_url_string());
-    });
+    full_url.push_str(&page_meta.to_url_string());
 
     let filters = filters.as_query_param();
     if !filters.is_empty() {

--- a/src/routes/transactions/handlers/module.rs
+++ b/src/routes/transactions/handlers/module.rs
@@ -24,7 +24,8 @@ pub async fn get_module_transactions(
         safe_address
     )?;
 
-    let page_meta = cursor.as_ref().map(|it| PageMetadata::from_cursor(it));
+    let page_meta: PageMetadata =
+        PageMetadata::from_cursor(cursor.as_ref().unwrap_or(&"".to_string()));
 
     let backend_txs = get_backend_page(
         &context,
@@ -47,7 +48,7 @@ pub async fn get_module_transactions(
             context,
             chain_id,
             safe_address,
-            page_meta.as_ref(),
+            &page_meta,
             backend_txs.next,
             filters,
             1,
@@ -56,7 +57,7 @@ pub async fn get_module_transactions(
             context,
             chain_id,
             safe_address,
-            page_meta.as_ref(),
+            &page_meta,
             backend_txs.previous,
             filters,
             -1,
@@ -91,14 +92,13 @@ fn build_cursor(
     context: &RequestContext,
     chain_id: &str,
     safe_address: &str,
-    page_meta: Option<&PageMetadata>,
+    page_meta: &PageMetadata,
     backend_page_url: Option<String>,
     filters: &ModuleFilters,
     direction: i64,
 ) -> Option<String> {
     backend_page_url.as_ref().map(|_| {
-        let cursor = page_meta
-            .map(|page_meta| offset_page_meta(page_meta, direction * (page_meta.limit as i64)));
+        let cursor = offset_page_meta(page_meta, direction * (page_meta.limit as i64));
 
         build_absolute_uri(
             context,
@@ -106,7 +106,7 @@ fn build_cursor(
                 crate::routes::transactions::routes::get_module_transactions(
                     chain_id = chain_id,
                     safe_address = safe_address,
-                    cursor = cursor,
+                    cursor = Some(cursor),
                     filters = (filters.to.to_owned(), filters.module.to_owned())
                 )
             ),

--- a/src/routes/transactions/handlers/multisig.rs
+++ b/src/routes/transactions/handlers/multisig.rs
@@ -23,7 +23,8 @@ pub async fn get_multisig_transactions(
         "/v1/safes/{}/multisig-transactions/",
         safe_address
     )?;
-    let page_meta = cursor.as_ref().map(|it| PageMetadata::from_cursor(it));
+    let page_meta: PageMetadata =
+        PageMetadata::from_cursor(cursor.as_ref().unwrap_or(&"".to_string()));
 
     let backend_txs = get_backend_page(
         &context,
@@ -46,7 +47,7 @@ pub async fn get_multisig_transactions(
             context,
             chain_id,
             safe_address,
-            page_meta.as_ref(),
+            &page_meta,
             backend_txs.next,
             filters,
             1,
@@ -55,7 +56,7 @@ pub async fn get_multisig_transactions(
             context,
             chain_id,
             safe_address,
-            page_meta.as_ref(),
+            &page_meta,
             backend_txs.previous,
             filters,
             -1,
@@ -90,14 +91,13 @@ fn build_cursor(
     context: &RequestContext,
     chain_id: &str,
     safe_address: &str,
-    page_meta: Option<&PageMetadata>,
+    page_meta: &PageMetadata,
     backend_page_url: Option<String>,
     filters: &MultisigFilters,
     direction: i64,
 ) -> Option<String> {
     backend_page_url.as_ref().map(|_| {
-        let cursor = page_meta
-            .map(|page_meta| offset_page_meta(page_meta, direction * (page_meta.limit as i64)));
+        let cursor = offset_page_meta(page_meta, direction * (page_meta.limit as i64));
 
         build_absolute_uri(
             context,
@@ -105,7 +105,7 @@ fn build_cursor(
                 crate::routes::transactions::routes::get_multisig_transactions(
                     chain_id = chain_id,
                     safe_address = safe_address,
-                    cursor = cursor,
+                    cursor = Some(cursor),
                     filters = (
                         filters.execution_date_gte.to_owned(),
                         filters.execution_date_lte.to_owned(),

--- a/src/routes/transactions/handlers/tests/transfers.rs
+++ b/src/routes/transactions/handlers/tests/transfers.rs
@@ -32,7 +32,7 @@ pub async fn get_incoming_transfers_no_filters() {
         });
 
     let mut transfer_request = Request::new(format!(
-        "https://safe-transaction.rinkeby.staging.gnosisdev.com/api/v1/safes/{}/incoming-transfers/?",
+        "https://safe-transaction.rinkeby.staging.gnosisdev.com/api/v1/safes/{}/incoming-transfers/?limit=20&offset=0",
         &safe_address
     ));
     transfer_request.timeout(Duration::from_millis(transaction_request_timeout()));
@@ -74,7 +74,6 @@ pub async fn get_incoming_transfers_no_filters() {
 
     let actual_status = response.status();
     let value = &response.into_string().await.unwrap();
-    println!("{}", &value);
     let actual = serde_json::from_str::<Page<TransactionListItem>>(&value).unwrap();
 
     assert_eq!(actual_status, Status::Ok);

--- a/src/routes/transactions/handlers/transfers.rs
+++ b/src/routes/transactions/handlers/transfers.rs
@@ -25,8 +25,8 @@ pub async fn get_incoming_transfers(
         safe_address
     )?;
 
-    let page_meta = cursor.as_ref().map(|it| PageMetadata::from_cursor(it));
-
+    let page_meta: PageMetadata =
+        PageMetadata::from_cursor(cursor.as_ref().unwrap_or(&"".to_string()));
     let backend_txs = get_backend_page(
         &context,
         chain_id,
@@ -48,7 +48,7 @@ pub async fn get_incoming_transfers(
             context,
             chain_id,
             safe_address,
-            page_meta.as_ref(),
+            &page_meta,
             backend_txs.next,
             filters,
             1,
@@ -57,7 +57,7 @@ pub async fn get_incoming_transfers(
             context,
             chain_id,
             safe_address,
-            page_meta.as_ref(),
+            &page_meta,
             backend_txs.previous,
             filters,
             -1,
@@ -93,21 +93,20 @@ fn build_cursor(
     context: &RequestContext,
     chain_id: &str,
     safe_address: &str,
-    page_meta: Option<&PageMetadata>,
+    page_meta: &PageMetadata,
     backend_page_url: Option<String>,
     filters: &TransferFilters,
     direction: i64,
 ) -> Option<String> {
     backend_page_url.as_ref().map(|_| {
-        let cursor = page_meta
-            .map(|page_meta| offset_page_meta(page_meta, direction * (page_meta.limit as i64)));
+        let cursor = offset_page_meta(page_meta, direction * (page_meta.limit as i64));
 
         build_absolute_uri(
             context,
             uri!(crate::routes::transactions::routes::get_incoming_transfers(
                 chain_id = chain_id,
                 safe_address = safe_address,
-                cursor = cursor,
+                cursor = Some(cursor),
                 filters = (
                     filters.execution_date_gte.to_owned(),
                     filters.execution_date_lte.to_owned(),


### PR DESCRIPTION
- If `/incoming-transfers` or `/module-transactions` or `/multisig-transactions` were used without any pagination query parameters, a default one wouldn't be added – a default of `limit=20&offset=0` is now set.
- Therefore, only one page was returned and the `next` cursor was `null`.