### PR TITLE
Fix links for cargo doc

### DIFF
--- a/.github/landing_page/index.html
+++ b/.github/landing_page/index.html
@@ -12,7 +12,7 @@
 <div id="root">
     <div class="App">
         <header class="App-header"><img src="./gnosis_safe_logo.png" class="App-logo" alt="logo">
-            <a class="App-link" href="https://gnosis.github.io/safe-client-gateway/docs/" rel="noopener noreferrer">
+            <a class="App-link" href="https://safe.global/safe-client-gateway/docs/" rel="noopener noreferrer">
                 <p>Safe Client Gateway</p>
             </a>
         </header>

--- a/README.md
+++ b/README.md
@@ -8,7 +8,7 @@ This project is a gateway between the Safe clients ([Android](https://github.com
 
 ## Documentation
 
-- [Client Gateway Wiki](https://gnosis.github.io/safe-client-gateway/)
+- [Client Gateway Wiki](https://safe.global/safe-client-gateway/)
 - [Safe developer documentation](https://docs.gnosis.io/safe/)
 
 ## Quickstart

--- a/src/routes/mod.rs
+++ b/src/routes/mod.rs
@@ -100,5 +100,5 @@ fn panic() -> Value {
 #[doc(hidden)]
 #[get("/")]
 pub fn root() -> Redirect {
-    Redirect::temporary("https://gnosis.github.io/safe-client-gateway/")
+    Redirect::temporary("https://safe.global/safe-client-gateway/")
 }


### PR DESCRIPTION
- https://gnosis.github.io/safe-client-gateway is no longer valid.
- It should be under https://safe.global/safe-client-gateway instead (the action needs to generate the docs with the correct link)