### PR TITLE
Remove format from GET /delegates endpoint

### DIFF
--- a/src/routes/delegates/routes.rs
+++ b/src/routes/delegates/routes.rs
@@ -5,9 +5,7 @@ use crate::utils::errors::ApiResult;
 use rocket::response::content;
 use rocket::serde::json::Json;
 
-#[get(
-    "/v1/chains/<chain_id>/delegates?<safe>&<delegate>&<delegator>&<label>"
-)]
+#[get("/v1/chains/<chain_id>/delegates?<safe>&<delegate>&<delegator>&<label>")]
 pub async fn get_delegates<'e>(
     context: RequestContext,
     chain_id: String,

--- a/src/routes/delegates/routes.rs
+++ b/src/routes/delegates/routes.rs
@@ -6,8 +6,7 @@ use rocket::response::content;
 use rocket::serde::json::Json;
 
 #[get(
-    "/v1/chains/<chain_id>/delegates?<safe>&<delegate>&<delegator>&<label>",
-    format = "application/json"
+    "/v1/chains/<chain_id>/delegates?<safe>&<delegate>&<delegator>&<label>"
 )]
 pub async fn get_delegates<'e>(
     context: RequestContext,


### PR DESCRIPTION
Closes #892

-  Remove `application/json` as the required format for the endpoint
- `GET /v1/chains/<chain_id>/delegates` should not require the `Accept` to be set to `application/json`
