### PR TITLE
Pin serde_repr patch version

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2098,9 +2098,9 @@ dependencies = [
 
 [[package]]
 name = "serde_repr"
-version = "0.1.7"
+version = "0.1.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "98d0516900518c29efa217c298fa1f4e6c6ffc85ae29fd7f4ee48f176e1a9ed5"
+checksum = "a2ad84e47328a31223de7fed7a4f5087f2d6ddfe586cf3ca25b7a165bc0a5aed"
 dependencies = [
  "proc-macro2",
  "quote",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -28,6 +28,6 @@ rocket_codegen = { version = "0.5.0-rc.2" }
 semver = "1.0.9"
 serde = { version = "1.0.137", features = ["derive"] }
 serde_json = { version = "1.0.81", features = ["raw_value"] }
-serde_repr = "0.1"
+serde_repr = "0.1.8"
 thiserror = "1.0.31"
 tokio = "1.16.1"


### PR DESCRIPTION
- Pins the patch version for `serde_repr` – we use it directly in the project and we want to update it on the patch level