### PR TITLE
Add Swagger link to README

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,7 +9,7 @@ This project is a gateway between the Safe clients ([Android](https://github.com
 ## Documentation
 
 - [Client Gateway Docs](https://safe.global/safe-client-gateway/)
-- [Swagger](https://safe-client.gnosis.io/swagger/index.html)
+- [Swagger](https://safe-client.gnosis.io/index.html)
 - [Safe developer documentation](https://docs.gnosis.io/safe/)
 
 ## Quickstart

--- a/README.md
+++ b/README.md
@@ -8,7 +8,8 @@ This project is a gateway between the Safe clients ([Android](https://github.com
 
 ## Documentation
 
-- [Client Gateway Wiki](https://safe.global/safe-client-gateway/)
+- [Client Gateway Docs](https://safe.global/safe-client-gateway/)
+- [Swagger](https://safe-client.gnosis.io/swagger/index.html)
 - [Safe developer documentation](https://docs.gnosis.io/safe/)
 
 ## Quickstart


### PR DESCRIPTION
Closes #917

- Add link to Swagger (production)
- Update entry: "Client Gateway Wiki" to "Client Gateway Docs" to represent better the resource on this link

The original issue also suggests to add to the project description – I did not do that because I think the description should be a short text (as we have right now) and we'd need to keep track of more places if this url is updated.
