### PR TITLE
Feature: safe apps url query param

### DIFF
--- a/src/routes/notifications/models.rs
+++ b/src/routes/notifications/models.rs
@@ -6,7 +6,7 @@ use serde::{Deserialize, Serialize};
 /// <summary>Example body of NotificationRegistrationRequest registering a device for push notifications</summary>
 ///
 /// ```json
-/// 
+///
 /// {
 ///  "uuid": "c50750df-700c-4b17-98ca-b95a5c27ca18",
 ///  "cloudMessagingToken": "eWv4Ya6OSaiuDI91S0_C6D:APA91bGpprbGOCa1Qev0h3vlMu2nXa9nWpaL7N9fEcX2G4byZ3TSKXircrMtuWg1H4nSG9Ugu7a7rgY1eDKAR9UaxgaP1egTRj3taqAfAQblApuiWFfRRkyxdD3N23t7wYi9ZBIXZ88Z",

--- a/src/routes/notifications/models.rs
+++ b/src/routes/notifications/models.rs
@@ -6,7 +6,7 @@ use serde::{Deserialize, Serialize};
 /// <summary>Example body of NotificationRegistrationRequest registering a device for push notifications</summary>
 ///
 /// ```json
-///
+/// 
 /// {
 ///  "uuid": "c50750df-700c-4b17-98ca-b95a5c27ca18",
 ///  "cloudMessagingToken": "eWv4Ya6OSaiuDI91S0_C6D:APA91bGpprbGOCa1Qev0h3vlMu2nXa9nWpaL7N9fEcX2G4byZ3TSKXircrMtuWg1H4nSG9Ugu7a7rgY1eDKAR9UaxgaP1egTRj3taqAfAQblApuiWFfRRkyxdD3N23t7wYi9ZBIXZ88Z",

--- a/src/routes/safe_apps/handlers.rs
+++ b/src/routes/safe_apps/handlers.rs
@@ -10,11 +10,13 @@ pub async fn safe_apps(
     context: &RequestContext,
     chain_id: &String,
     client_url: &Option<String>,
+    url: &Option<String>,
 ) -> ApiResult<Vec<SafeApp>> {
     let url = config_uri!(
-        "/v1/safe-apps/?chainId={}&clientUrl={}",
+        "/v1/safe-apps/?chainId={}&clientUrl={}&url={}",
         chain_id,
-        client_url.as_deref().unwrap_or("")
+        client_url.as_deref().unwrap_or(""),
+        url.as_deref().unwrap_or("")
     );
     let data = RequestCached::new_from_context(url, &context, ChainCache::from(chain_id.as_str()))
         .cache_duration(safe_apps_cache_duration())

--- a/src/routes/safe_apps/routes.rs
+++ b/src/routes/safe_apps/routes.rs
@@ -17,6 +17,7 @@ use rocket_okapi::openapi;
 /// ## Query parameters
 ///
 /// - `client_url`: The URL of the client application. Optional.
+/// - `url`: Filter Safe Apps available from url. url needs to be an exact match. Optional.
 ///
 /// ## Examples
 /// [
@@ -64,13 +65,14 @@ use rocket_okapi::openapi;
 ///     }
 /// ]
 #[openapi(tag = "SafeApps")]
-#[get("/v1/chains/<chain_id>/safe-apps?<client_url>")]
+#[get("/v1/chains/<chain_id>/safe-apps?<client_url>&<url>")]
 pub async fn get_safe_apps(
     context: RequestContext,
     chain_id: String,
     client_url: Option<String>,
+    url: Option<String>,
 ) -> ApiResult<content::RawJson<String>> {
     Ok(content::RawJson(serde_json::to_string(
-        &safe_apps(&context, &chain_id, &client_url).await?,
+        &safe_apps(&context, &chain_id, &client_url, &url).await?,
     )?))
 }

--- a/src/routes/safe_apps/tests/json/response_safe_apps_url_query.json
+++ b/src/routes/safe_apps/tests/json/response_safe_apps_url_query.json
@@ -1,0 +1,14 @@
+[
+  {
+    "id": 26,
+    "url": "https://test.app",
+    "name": "Test App",
+    "iconUrl": "https://test.app/logo.svg",
+    "description": "Some cool app",
+    "chainIds": ["1", "137"],
+    "provider": null,
+    "accessControl": {
+      "type": "NO_RESTRICTIONS"
+    }
+  }
+]

--- a/src/routes/safe_apps/tests/mod.rs
+++ b/src/routes/safe_apps/tests/mod.rs
@@ -3,3 +3,6 @@ mod routes;
 pub(crate) const RESPONSE_SAFE_APPS: &str = include_str!("json/response_safe_apps.json");
 pub(crate) const RESPONSE_SAFE_APPS_WITH_TAGS: &str =
     include_str!("json/response_safe_apps_with_tags.json");
+pub(crate) const RESPONSE_SAFE_APPS_WITH_URL_QUERY: &str = include_str!(
+    "json/response_safe_apps_url_query.json"
+);

--- a/src/routes/safe_apps/tests/mod.rs
+++ b/src/routes/safe_apps/tests/mod.rs
@@ -3,6 +3,5 @@ mod routes;
 pub(crate) const RESPONSE_SAFE_APPS: &str = include_str!("json/response_safe_apps.json");
 pub(crate) const RESPONSE_SAFE_APPS_WITH_TAGS: &str =
     include_str!("json/response_safe_apps_with_tags.json");
-pub(crate) const RESPONSE_SAFE_APPS_WITH_URL_QUERY: &str = include_str!(
-    "json/response_safe_apps_url_query.json"
-);
+pub(crate) const RESPONSE_SAFE_APPS_WITH_URL_QUERY: &str =
+    include_str!("json/response_safe_apps_url_query.json");

--- a/src/routes/safe_apps/tests/routes.rs
+++ b/src/routes/safe_apps/tests/routes.rs
@@ -1,5 +1,7 @@
 use crate::routes::safe_apps::models::SafeApp;
-use crate::routes::safe_apps::tests::{RESPONSE_SAFE_APPS_WITH_TAGS, RESPONSE_SAFE_APPS_WITH_URL_QUERY};
+use crate::routes::safe_apps::tests::{
+    RESPONSE_SAFE_APPS_WITH_TAGS, RESPONSE_SAFE_APPS_WITH_URL_QUERY,
+};
 use crate::tests::main::setup_rocket;
 use crate::utils::errors::{ApiError, ErrorDetails};
 use crate::utils::http_client::{MockHttpClient, Request, Response};
@@ -186,12 +188,13 @@ async fn safe_apps_url_query_param() {
             mock_http_client,
             routes![super::super::routes::get_safe_apps],
         )
-            .await,
+        .await,
     )
-        .await
-        .expect("valid rocket instance");
+    .await
+    .expect("valid rocket instance");
     let response = {
-        let mut response = client.get("/v1/chains/137/safe-apps?client_url=https://gnosis-safe.io&url=https://test.app");
+        let mut response = client
+            .get("/v1/chains/137/safe-apps?client_url=https://gnosis-safe.io&url=https://test.app");
         response.add_header(Header::new("Host", "test.gnosis.io"));
         response.dispatch().await
     };


### PR DESCRIPTION
**This PR**:
- Adds support for `url` query param for `safe-apps` endpoint as in #958 

**Additional context**:
We already have a [provider](https://github.com/gnosis/safe-client-gateway/blob/248a9a1bf8b45fb8d6bcb80a5ef22d5fd78768cb/src/providers/info.rs#L157) for safe apps info which theoretically could be reused, but I didn't find a good way to glue it into the current problem