### PR TITLE
Invalidate Mainnet cache in /v2/flush

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2081,7 +2081,7 @@ checksum = "71d301d4193d031abdd79ff7e3dd721168a9572ef3fe51a1517aba235bd8f86e"
 
 [[package]]
 name = "safe-client-gateway"
-version = "3.35.0"
+version = "3.35.1"
 dependencies = [
  "bb8-redis",
  "bigdecimal",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "safe-client-gateway"
-version = "3.35.0"
+version = "3.35.1"
 authors = ["jpalvarezl <jose.alvarez@gnosis.io>", "rmeissner <richard@gnosis.io>", "fmrsabino <frederico@gnosis.io>"]
 edition = "2018"
 

--- a/src/cache/cache_operations.rs
+++ b/src/cache/cache_operations.rs
@@ -24,14 +24,14 @@ pub struct Invalidate {
     pattern: InvalidationPattern,
 }
 
-#[derive(Deserialize, Debug)]
+#[derive(Deserialize, Debug, Clone)]
 pub enum InvalidationScope {
     Requests,
     Responses,
     Both,
 }
 
-#[derive(Deserialize, Debug)]
+#[derive(Deserialize, Debug, Clone)]
 #[serde(tag = "invalidate", content = "pattern_details")]
 pub enum InvalidationPattern {
     Any(InvalidationScope, String),

--- a/src/routes/hooks/routes.rs
+++ b/src/routes/hooks/routes.rs
@@ -74,6 +74,12 @@ pub async fn post_flush_events(
     _token: AuthorizationToken,
     invalidation_pattern: Json<InvalidationPattern>,
 ) -> ApiResult<()> {
+    Invalidate::new(
+        invalidation_pattern.0.clone(),
+        context.cache(ChainCache::Mainnet),
+    )
+    .execute()
+    .await;
     Invalidate::new(invalidation_pattern.0, context.cache(ChainCache::Other))
         .execute()
         .await;


### PR DESCRIPTION
- With the introduction of two caches (one for Mainnet and the other one for all the other networks), The `/v2/flush` route was executing the invalidation only for all the other chains.
- This means no Mainnet data was invalidated when `/v2/flush` was triggered.