### PR TITLE
Set `latest` tag for releases on docker

### DIFF
--- a/scripts/deploy_docker.sh
+++ b/scripts/deploy_docker.sh
@@ -47,3 +47,10 @@ docker push $runtime_image_id
 
 # Push builder image to remote repository for next build
 docker push $cached_builder_image_id
+
+# If release, set latest docker tag
+case $1 in v*)
+    latest_image_id="$DOCKERHUB_ORG/$DOCKERHUB_PROJECT:latest"
+    docker tag $runtime_image_id $latest_image_id
+    docker push $latest_image_id
+esac


### PR DESCRIPTION
- We took a look on the different official dockerhub images (https://hub.docker.com/search?q=&type=image&image_filter=official) and they all follow the same "de facto" standard of setting `latest` to the last release of the application.
- They use `stable` for older versions or LTS, and in our case we don't have that and we want users running the last versions of our services.
- With this `latest` tag it will be easy for users to be updated and not having to manually update versions (like in https://github.com/safe-global/safe-infrastructure)