### PR TITLE
Update org in docker images

### DIFF
--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -154,7 +154,7 @@ jobs:
   deploy:
     runs-on: ubuntu-latest
     env:
-      DOCKERHUB_ORG: gnosispm
+      DOCKERHUB_ORG: safeglobal
       DOCKERHUB_PROJECT: safe-client-gateway
     needs: [ rustfmt, tests ]
     if: github.ref == 'refs/heads/main' || github.ref == 'refs/heads/develop' || startsWith(github.ref, 'refs/tags/v')


### PR DESCRIPTION
- Changes `gnosispm` to `safeglobal` when building and pushing Docker images
