### PR TITLE
Add GET /<safe_address>/messages endpoint

### DIFF
--- a/src/config/mod.rs
+++ b/src/config/mod.rs
@@ -173,6 +173,10 @@ pub fn feature_flag_balances_rate_implementation() -> bool {
     env_with_default("FEATURE_FLAG_BALANCES_RATE_IMPLEMENTATION", false)
 }
 
+pub fn is_messages_feature_enabled() -> bool {
+    env_with_default("FEATURE_MESSAGES", false)
+}
+
 pub fn is_preview_endpoint_enabled() -> bool {
     env_with_default("FEATURE_PREVIEW_ENDPOINT", false)
 }

--- a/src/routes/messages/backend_models.rs
+++ b/src/routes/messages/backend_models.rs
@@ -1,0 +1,35 @@
+use chrono::{DateTime, Utc};
+use serde::Deserialize;
+
+#[derive(Deserialize, Debug)]
+#[serde(rename_all = "SCREAMING_SNAKE_CASE")]
+pub(super) enum SignatureType {
+    ContractSignature,
+    ApprovedHash,
+    EOA,
+    EthSign,
+}
+
+#[derive(Deserialize, Debug)]
+#[serde(rename_all = "camelCase")]
+pub(super) struct Confirmation {
+    pub(super) created: DateTime<Utc>,
+    pub(super) modified: DateTime<Utc>,
+    pub(super) owner: String,
+    pub(super) signature: String,
+    pub(super) signature_type: SignatureType,
+}
+
+#[derive(Deserialize, Debug)]
+#[serde(rename_all = "camelCase")]
+pub(super) struct Message {
+    pub(super) created: DateTime<Utc>,
+    pub(super) modified: DateTime<Utc>,
+    pub(super) safe: String,
+    pub(super) message_hash: String,
+    pub(super) message: String,
+    pub(super) proposed_by: String,
+    pub(super) description: String,
+    pub(super) confirmations: Vec<Confirmation>,
+    pub(super) prepared_signature: Option<String>,
+}

--- a/src/routes/messages/backend_models.rs
+++ b/src/routes/messages/backend_models.rs
@@ -29,7 +29,7 @@ pub(super) struct Message {
     pub(super) message_hash: String,
     pub(super) message: String,
     pub(super) proposed_by: String,
-    pub(super) description: String,
+    pub(super) safe_app_id: u64,
     pub(super) confirmations: Vec<Confirmation>,
     pub(super) prepared_signature: Option<String>,
 }

--- a/src/routes/messages/frontend_models.rs
+++ b/src/routes/messages/frontend_models.rs
@@ -1,0 +1,36 @@
+use crate::common::models::addresses::AddressEx;
+use serde::Serialize;
+
+#[derive(Serialize, Debug)]
+#[serde(rename_all = "SCREAMING_SNAKE_CASE")]
+pub(super) enum MessageStatus {
+    NeedsConfirmation,
+    Confirmed,
+}
+
+#[derive(Serialize, Debug)]
+#[serde(rename_all = "camelCase")]
+pub(super) struct Confirmation {
+    pub(super) owner: AddressEx,
+    pub(super) signature: String,
+}
+
+#[derive(Serialize, Debug)]
+#[serde(tag = "type", rename_all = "SCREAMING_SNAKE_CASE")]
+pub(super) enum Message {
+    #[serde(rename_all = "camelCase")]
+    Message {
+        message_hash: String,
+        status: MessageStatus,
+        logo_uri: String,
+        name: String,
+        message: String,
+        creation_timestamp: i64,
+        modified_timestamp: i64,
+        confirmations_submitted: usize,
+        confirmations_required: usize,
+        proposed_by: AddressEx,
+        confirmations: Vec<Confirmation>,
+        prepared_signature: Option<String>,
+    },
+}

--- a/src/routes/messages/mod.rs
+++ b/src/routes/messages/mod.rs
@@ -1,0 +1,4 @@
+pub mod routes;
+
+mod backend_models;
+mod frontend_models;

--- a/src/routes/messages/routes.rs
+++ b/src/routes/messages/routes.rs
@@ -1,0 +1,187 @@
+use super::backend_models::Message;
+use super::frontend_models::{Confirmation as FrontendConfirmation, Message as FrontendMessage};
+use crate::cache::cache_operations::RequestCached;
+use crate::cache::manager::ChainCache;
+use crate::common::models::addresses::AddressEx;
+use crate::common::models::page::{Page, PageMetadata};
+use crate::providers::ext::InfoProviderExt;
+use crate::providers::info::{DefaultInfoProvider, InfoProvider, SafeInfo};
+use crate::routes::messages::backend_models::Confirmation;
+use crate::routes::messages::frontend_models::MessageStatus;
+use crate::utils::context::RequestContext;
+use crate::utils::errors::{ApiError, ApiResult, ErrorDetails};
+use crate::utils::urls::build_absolute_uri;
+use reqwest::Url;
+use rocket::futures::future;
+use rocket::response::content;
+use rocket_okapi::openapi;
+use std::borrow::Cow;
+
+#[openapi(tag = "Messages")]
+#[get("/v1/chains/<chain_id>/safes/<safe_address>/messages?<cursor>")]
+pub async fn get_messages(
+    context: RequestContext,
+    chain_id: String,
+    safe_address: String,
+    cursor: Option<String>,
+) -> ApiResult<content::RawJson<String>> {
+    let info_provider = DefaultInfoProvider::new(&chain_id, &context);
+    let page_metadata = PageMetadata::from_cursor(cursor.as_ref().unwrap_or(&"".to_string()));
+    let safe_info = info_provider.safe_info(&safe_address).await?;
+
+    // Build Safe Transaction Service URL (with pagination)
+    let url = core_uri!(info_provider, "/v1/safes/{}/messages/", safe_address)?;
+    let mut url = Url::parse(&url).map_err(|_| ApiError {
+        status: 500,
+        details: ErrorDetails {
+            code: 500,
+            message: None,
+            arguments: None,
+            debug: None,
+        },
+    })?;
+    url.set_query(Some(&page_metadata.to_url_string()));
+
+    // Request
+    let body = RequestCached::new_from_context(
+        url.into_string(),
+        &context,
+        ChainCache::from(chain_id.clone().as_str()),
+    )
+    .execute()
+    .await?;
+
+    let messages_page: Page<Message> = serde_json::from_str::<Page<Message>>(&body)?;
+    let messages: Vec<FrontendMessage> = future::join_all(
+        messages_page
+            .results
+            .iter()
+            .map(|message| map_message(&info_provider, &safe_info, &message)),
+    )
+    .await;
+
+    let next_pagination: Option<PageMetadata> = match messages_page.next {
+        None => None,
+        Some(next) => page_metadata_from_url(&next),
+    };
+
+    let previous_pagination: Option<PageMetadata> = match messages_page.previous {
+        None => None,
+        Some(previous) => page_metadata_from_url(&previous),
+    };
+
+    let body = Page {
+        next: get_route_url(&context, &chain_id, &safe_address, &next_pagination),
+        previous: get_route_url(&context, &chain_id, &safe_address, &previous_pagination),
+        results: messages,
+    };
+
+    let body = serde_json::to_string(&body)?;
+    return Ok(content::RawJson(body));
+}
+
+fn get_route_url(
+    context: &RequestContext,
+    chain_id: &str,
+    safe_address: &str,
+    page_metadata: &Option<PageMetadata>,
+) -> Option<String> {
+    let cursor: String = page_metadata
+        .as_ref()
+        .map(|page_metadata| page_metadata.to_url_string())?;
+    let absolute_uri: String = build_absolute_uri(
+        &context,
+        uri!(get_messages(
+            chain_id = chain_id.to_string(),
+            safe_address = safe_address.to_string(),
+            cursor = Some(cursor),
+        )),
+    );
+    return Some(absolute_uri);
+}
+
+fn page_metadata_from_url(url: &str) -> Option<PageMetadata> {
+    let url = Url::parse(url).ok()?;
+    let mut query_pairs = url.query_pairs();
+    let mut limit: u64 = 20;
+    let mut offset: u64 = 0;
+
+    for pair in query_pairs {
+        match pair.0 {
+            Cow::Borrowed("limit") => {
+                limit = pair.1.parse::<u64>().ok()?;
+            }
+            Cow::Borrowed("offset") => {
+                offset = pair.1.parse::<u64>().ok()?;
+            }
+            _ => {}
+        }
+    }
+
+    return Some(PageMetadata { offset, limit });
+}
+
+async fn map_message(
+    info_provider: &(impl InfoProvider + Sync),
+    safe_info: &SafeInfo,
+    message: &Message,
+) -> FrontendMessage {
+    let confirmations_required = safe_info.threshold as usize;
+    let confirmations_submitted = message.confirmations.len();
+
+    // Known Address for proposed_by
+    let proposed_by: AddressEx = info_provider
+        .address_ex_from_contracts_or_default(&message.proposed_by)
+        .await;
+
+    // Known address for each confirmation
+    let confirmations: Vec<FrontendConfirmation> = future::join_all(
+        message
+            .confirmations
+            .iter()
+            .map(|confirmation| map_confirmation(info_provider, &confirmation)),
+    )
+    .await;
+
+    return FrontendMessage::Message {
+        message_hash: message.message_hash.to_string(),
+        status: if confirmations_submitted >= confirmations_required {
+            MessageStatus::Confirmed
+        } else {
+            MessageStatus::NeedsConfirmation
+        },
+        logo_uri: "".to_string(), // TODO pending tx-service change
+        name: "".to_string(),     // TODO pending tx-service change
+        message: message.message.to_string(),
+        creation_timestamp: message.created.timestamp_millis(),
+        modified_timestamp: message.modified.timestamp_millis(),
+        confirmations_submitted,
+        confirmations_required,
+        proposed_by,
+        confirmations,
+        prepared_signature: match &message.prepared_signature {
+            None => None,
+            Some(value) => {
+                if confirmations_submitted >= confirmations_required {
+                    Some(value.to_string())
+                } else {
+                    None
+                }
+            }
+        },
+    };
+}
+
+async fn map_confirmation(
+    info_provider: &(impl InfoProvider + Sync),
+    confirmation: &Confirmation,
+) -> FrontendConfirmation {
+    let owner: AddressEx = info_provider
+        .address_ex_from_contracts_or_default(&confirmation.owner)
+        .await;
+
+    return FrontendConfirmation {
+        owner,
+        signature: confirmation.signature.to_string(),
+    };
+}

--- a/src/routes/messages/routes.rs
+++ b/src/routes/messages/routes.rs
@@ -150,8 +150,8 @@ async fn map_message(
         } else {
             MessageStatus::NeedsConfirmation
         },
-        logo_uri: "".to_string(), // TODO pending tx-service change
-        name: "".to_string(),     // TODO pending tx-service change
+        logo_uri: "".to_string(), // TODO fetch from safe-config-service using Safe App Id
+        name: "".to_string(),     // TODO fetch from safe-config-service using Safe App Id
         message: message.message.to_string(),
         creation_timestamp: message.created.timestamp_millis(),
         modified_timestamp: message.modified.timestamp_millis(),

--- a/src/routes/mod.rs
+++ b/src/routes/mod.rs
@@ -20,6 +20,7 @@ pub mod delegates;
 pub mod health;
 #[doc(hidden)]
 pub mod hooks;
+pub mod messages;
 /// # Notification endpoints
 pub mod notifications;
 /// # SafeApps endpoints
@@ -75,6 +76,7 @@ pub fn active_routes() -> Vec<Route> {
         delegates::routes::delete_safe_delegate,
         delegates::routes::get_delegates,
         delegates::routes::post_delegate,
+        messages::routes::get_messages,
         notifications::routes::delete_notification_registration,
         safes::routes::get_safe_info,
         safes::routes::get_owners,

--- a/src/routes/mod.rs
+++ b/src/routes/mod.rs
@@ -3,7 +3,7 @@ use rocket::serde::json::{json, Value};
 use rocket::{Catcher, Route};
 use rocket_okapi::openapi_get_routes;
 
-use crate::config::is_preview_endpoint_enabled;
+use crate::config::{is_messages_feature_enabled, is_preview_endpoint_enabled};
 
 /// # About endpoint
 pub mod about;
@@ -60,6 +60,12 @@ pub fn active_routes() -> Vec<Route> {
         routes![]
     };
 
+    let messages_routes = if is_messages_feature_enabled() {
+        routes![messages::routes::get_messages]
+    } else {
+        routes![]
+    };
+
     let openapi = openapi_get_routes![
         about::routes::backbone,
         about::routes::get_about,
@@ -76,7 +82,6 @@ pub fn active_routes() -> Vec<Route> {
         delegates::routes::delete_safe_delegate,
         delegates::routes::get_delegates,
         delegates::routes::post_delegate,
-        messages::routes::get_messages,
         notifications::routes::delete_notification_registration,
         safes::routes::get_safe_info,
         safes::routes::get_owners,
@@ -89,7 +94,13 @@ pub fn active_routes() -> Vec<Route> {
         transactions::routes::get_multisig_transactions,
         health::routes::health
     ];
-    return [&no_openapi[..], &preview_route[..], &openapi[..]].concat();
+    return [
+        &no_openapi[..],
+        &preview_route[..],
+        &messages_routes[..],
+        &openapi[..],
+    ]
+    .concat();
 }
 
 #[doc(hidden)]


### PR DESCRIPTION
See #998

- Adds `GET /v1/chains/<chain_id>/safes/<safe_address>/messages` route
- This endpoint maps the messages returned by the Safe Transaction Service (`/v1/safes/<safe-address>/messages/`)
- The mapping performs the following:
  * If a message reached the number of confirmations required, `status: CONFIRMED` is returned. Else `status: NEEDS_CONFIRMATION` is returned
  * `creationTimestamp` and `modifiedTimestamp` are converted to UNIX timestamps (in milliseconds)
  * `preparedSignature` is only returned if the message is confirmed. It returns `null` otherwise.
  * `proposedBy` is converted to a "known address" payload
  * Each `confirmation.owner` is converted to a "known address" payload

There are still some tasks that need to be tackled:
- A feature flag should be set so that this endpoint doesn't block production releases
- A header that groups messages that were created on the same date needs to be added under `results`
- Tests need to be added
- The `logoUri` and `name` of the `Message` payload are not set (empty strings are returned) – this data will be retrieved from the Safe Config Service

My suggestion is to tackle the above in separate PRs to fast-track trying out this new endpoint (upon approval).