### PR TITLE
Add POST /<safe_address>/messages endpoint

### DIFF
--- a/src/routes/messages/frontend_models.rs
+++ b/src/routes/messages/frontend_models.rs
@@ -1,5 +1,5 @@
 use crate::common::models::addresses::AddressEx;
-use serde::Serialize;
+use serde::{Deserialize, Serialize};
 
 #[derive(Serialize, Debug)]
 #[serde(rename_all = "SCREAMING_SNAKE_CASE")]
@@ -33,4 +33,12 @@ pub(super) enum Message {
         confirmations: Vec<Confirmation>,
         prepared_signature: Option<String>,
     },
+}
+
+#[derive(Deserialize, Serialize, Debug)]
+#[serde(rename_all = "camelCase")]
+pub struct CreateMessage {
+    message: String,
+    safe_app_id: u64,
+    signature: String,
 }

--- a/src/routes/mod.rs
+++ b/src/routes/mod.rs
@@ -40,6 +40,7 @@ pub fn active_routes() -> Vec<Route> {
         // rocket_okapi don't support lifetimes
         // https://github.com/GREsau/okapi/issues/84
         contracts::routes::post_data_decoder,
+        messages::routes::create_message,
         notifications::routes::post_notification_registration,
         safes::routes::post_safe_gas_estimation,
         safes::routes::post_safe_gas_estimation_v2,

--- a/src/routes/mod.rs
+++ b/src/routes/mod.rs
@@ -40,7 +40,6 @@ pub fn active_routes() -> Vec<Route> {
         // rocket_okapi don't support lifetimes
         // https://github.com/GREsau/okapi/issues/84
         contracts::routes::post_data_decoder,
-        messages::routes::create_message,
         notifications::routes::post_notification_registration,
         safes::routes::post_safe_gas_estimation,
         safes::routes::post_safe_gas_estimation_v2,
@@ -62,7 +61,10 @@ pub fn active_routes() -> Vec<Route> {
     };
 
     let messages_routes = if is_messages_feature_enabled() {
-        routes![messages::routes::get_messages]
+        routes![
+            messages::routes::get_messages,
+            messages::routes::create_message
+        ]
     } else {
         routes![]
     };


### PR DESCRIPTION
- Adds `POST /v1/chains/<chain_id>/safes/<safe_address>/messages` endpoint
- This endpoint creates a Message on the Safe Transaction Service for a specific Safe
- The payload should contain the `message`, the underlying `safeAppId` and the `signature` from one of the owners of the Safe

Tests will be added under a separate PR.