### PR TITLE
Retrieve Safe App info for signed messages

### DIFF
--- a/src/routes/messages/backend_models.rs
+++ b/src/routes/messages/backend_models.rs
@@ -29,7 +29,7 @@ pub(super) struct Message {
     pub(super) message_hash: String,
     pub(super) message: String,
     pub(super) proposed_by: String,
-    pub(super) safe_app_id: u64,
+    pub(super) safe_app_id: Option<u64>,
     pub(super) confirmations: Vec<Confirmation>,
     pub(super) prepared_signature: Option<String>,
 }

--- a/src/routes/messages/frontend_models.rs
+++ b/src/routes/messages/frontend_models.rs
@@ -22,8 +22,8 @@ pub(super) enum Message {
     Message {
         message_hash: String,
         status: MessageStatus,
-        logo_uri: String,
-        name: String,
+        logo_uri: Option<String>,
+        name: Option<String>,
         message: String,
         creation_timestamp: i64,
         modified_timestamp: i64,


### PR DESCRIPTION
- Retrieves Safe App info (`name` and `logoUri`) for `Message`
- Adds `safe_app_info_by_id` to `InfoProvider` – this function tries to retrieve a Safe App with the given `id`. If the Safe App is not found, an `ApiError` with `404` is returned
- Sets `safeAppId` as nullable – the Safe Transaction Service supports messages without an associated `safeAppId`
