### PR TITLE
Set message as of type String or BTreeMap

### DIFF
--- a/src/routes/messages/backend_models.rs
+++ b/src/routes/messages/backend_models.rs
@@ -1,5 +1,6 @@
 use chrono::{DateTime, Utc};
 use serde::Deserialize;
+use std::collections::BTreeMap;
 
 #[derive(Deserialize, Debug)]
 #[serde(rename_all = "SCREAMING_SNAKE_CASE")]
@@ -27,9 +28,16 @@ pub(super) struct Message {
     pub(super) modified: DateTime<Utc>,
     pub(super) safe: String,
     pub(super) message_hash: String,
-    pub(super) message: String,
+    pub(super) message: MessageValue,
     pub(super) proposed_by: String,
     pub(super) safe_app_id: Option<u64>,
     pub(super) confirmations: Vec<Confirmation>,
     pub(super) prepared_signature: Option<String>,
+}
+
+#[derive(Deserialize, Debug)]
+#[serde(untagged)]
+pub enum MessageValue {
+    String(String),
+    Object(BTreeMap<String, serde_json::Value>),
 }

--- a/src/routes/messages/frontend_models.rs
+++ b/src/routes/messages/frontend_models.rs
@@ -1,5 +1,6 @@
 use crate::common::models::addresses::AddressEx;
 use serde::{Deserialize, Serialize};
+use std::collections::BTreeMap;
 
 #[derive(Serialize, Debug)]
 #[serde(rename_all = "SCREAMING_SNAKE_CASE")]
@@ -24,7 +25,7 @@ pub(super) enum Message {
         status: MessageStatus,
         logo_uri: Option<String>,
         name: Option<String>,
-        message: String,
+        message: MessageValue,
         creation_timestamp: i64,
         modified_timestamp: i64,
         confirmations_submitted: usize,
@@ -47,4 +48,11 @@ pub struct CreateMessage {
 #[serde(rename_all = "camelCase")]
 pub struct UpdateMessage {
     signature: String,
+}
+
+#[derive(Serialize, Debug)]
+#[serde(untagged)]
+pub enum MessageValue {
+    String(String),
+    Object(BTreeMap<String, serde_json::Value>),
 }

--- a/src/routes/messages/routes.rs
+++ b/src/routes/messages/routes.rs
@@ -1,10 +1,13 @@
 use super::backend_models::Message;
-use super::frontend_models::{Confirmation as FrontendConfirmation, Message as FrontendMessage};
+use super::frontend_models::{
+    Confirmation as FrontendConfirmation, Message as FrontendMessage,
+    MessageValue as FrontendMessageValue,
+};
 use crate::common::models::addresses::AddressEx;
 use crate::common::models::page::{Page, PageMetadata};
 use crate::providers::ext::InfoProviderExt;
 use crate::providers::info::{DefaultInfoProvider, InfoProvider, SafeInfo};
-use crate::routes::messages::backend_models::Confirmation;
+use crate::routes::messages::backend_models::{Confirmation, MessageValue};
 use crate::routes::messages::frontend_models::{CreateMessage, MessageStatus, UpdateMessage};
 use crate::utils::context::RequestContext;
 use crate::utils::errors::{ApiError, ApiResult, ErrorDetails};
@@ -205,7 +208,10 @@ async fn map_message(
         },
         name: safe_app_name_logo.0,
         logo_uri: safe_app_name_logo.1,
-        message: message.message.to_string(),
+        message: match &message.message {
+            MessageValue::String(value) => FrontendMessageValue::String(value.to_string()),
+            MessageValue::Object(value) => FrontendMessageValue::Object(value.clone()),
+        },
         creation_timestamp: message.created.timestamp_millis(),
         modified_timestamp: message.modified.timestamp_millis(),
         confirmations_submitted,


### PR DESCRIPTION
- Sets the value of `Message.message` as either a `String` or a `BTreeMap<String, serde_json::Value>`
- The `message` value can contain a map structure which is not a `String` and this was not previously supported
