### PR TITLE
Group messages by date

### DIFF
--- a/src/routes/messages/frontend_models.rs
+++ b/src/routes/messages/frontend_models.rs
@@ -18,7 +18,7 @@ pub(super) struct Confirmation {
 
 #[derive(Serialize, Debug)]
 #[serde(tag = "type", rename_all = "SCREAMING_SNAKE_CASE")]
-pub(super) enum Message {
+pub(super) enum MessageItem {
     #[serde(rename_all = "camelCase")]
     Message {
         message_hash: String,
@@ -34,6 +34,8 @@ pub(super) enum Message {
         confirmations: Vec<Confirmation>,
         prepared_signature: Option<String>,
     },
+    #[serde(rename_all = "camelCase")]
+    DateLabel { timestamp: i64 },
 }
 
 #[derive(Deserialize, Serialize, Debug)]


### PR DESCRIPTION
- Groups messages from `GET /v1/chains/<chain_id>/safes/<safe_address>/messages` by day
- Introduces `DateLabel` as a type that can be returned by the message list – `type: DATE_LABEL`
- The grouping works only with the current page returned, if the next page contains entries on the same day, a `DATE_LABEL` would be returned for those too
