### PR TITLE
Add messages_tag to Safe Info endpoint

### DIFF
--- a/src/routes/messages/backend_models.rs
+++ b/src/routes/messages/backend_models.rs
@@ -23,9 +23,9 @@ pub(super) struct Confirmation {
 
 #[derive(Deserialize, Debug)]
 #[serde(rename_all = "camelCase")]
-pub(super) struct Message {
+pub(crate) struct Message {
     pub(super) created: DateTime<Utc>,
-    pub(super) modified: DateTime<Utc>,
+    pub(crate) modified: DateTime<Utc>,
     pub(super) safe: String,
     pub(super) message_hash: String,
     pub(super) message: MessageValue,

--- a/src/routes/messages/mod.rs
+++ b/src/routes/messages/mod.rs
@@ -1,4 +1,4 @@
 pub mod routes;
 
-mod backend_models;
+pub(crate) mod backend_models;
 mod frontend_models;

--- a/src/routes/safes/models.rs
+++ b/src/routes/safes/models.rs
@@ -26,6 +26,9 @@ pub struct SafeLastChanges {
     pub collectibles_tag: String,
     pub tx_queued_tag: String,
     pub tx_history_tag: String,
+    // Can be String once the Messages feature is considered stable
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub messages_tag: Option<String>,
 }
 
 #[derive(Serialize, Debug, PartialEq)]


### PR DESCRIPTION
- The Safe Info endpoint `GET /v1/chains/<chain_id>/safes/<safe_address>` now returns a `messages_tag` if `FEATURE_MESSAGES` is set to `true`
- The tag is generated by retrieving the most recently modified message
- If the retrieval is successful the respective UNIX timestamp is returned, else the current UNIX timestamp is returned
- Due to the project structure, `messages::backend_models` had to be made available to the rest of the application in order for the Safe Info route to be able to access the `Message` model. The `modified` field also had to be made publicly available to the crate for the same reason.
