### PR TITLE
Add route to get message by hash

### DIFF
--- a/src/routes/mod.rs
+++ b/src/routes/mod.rs
@@ -64,7 +64,8 @@ pub fn active_routes() -> Vec<Route> {
         routes![
             messages::routes::get_messages,
             messages::routes::create_message,
-            messages::routes::update_message
+            messages::routes::update_message,
+            messages::routes::get_message,
         ]
     } else {
         routes![]


### PR DESCRIPTION
- Adds `GET /v1/chains/<chain_id>/messages/<message_hash>`
- It returns the `Message` associated with `message_hash`

The payload is the same as the message item returned by the `GET /v1/chains/<chain_id>/safes/<safe_address>/messages` endpoint

```javascript
{
  "type": "MESSAGE",
  "messageHash": <string>,
  "status": 'NEEDS_CONFIRMATION' | 'CONFIRMED',
  "logoUri": <string>, // optional
  "name": <string>, // optional
  "message": <string>,
  "creationTimestamp": <number>,
  "modifiedTimestamp": <number>,
  "confirmationsSubmitted": <number>,
  "confirmationsRequired": <number>,
  "proposedBy": {
    "value": <address-string>,
    "name": <string>, // optional
    "logoUri": <uri-string> // optional
  },
  "confirmations": [
    {
      "owner": {
        "value": <address-string>,
        "name": <string>, // optional
        "logoUri": <uri-string> // optional
      },
      "signature": <string>
    }
  ],
  "preparedSignature": <string> // optional
}
```
