### PR TITLE
Set Safe App ID as optional

### DIFF
--- a/src/routes/messages/frontend_models.rs
+++ b/src/routes/messages/frontend_models.rs
@@ -42,7 +42,7 @@ pub(super) enum MessageItem {
 #[serde(rename_all = "camelCase")]
 pub struct CreateMessage {
     message: String,
-    safe_app_id: u64,
+    safe_app_id: Option<u64>,
     signature: String,
 }
 


### PR DESCRIPTION
- Sets `safeAppId` as an optional parameter when creating a new `Message`
