### PR TITLE
Use Ubuntu 20.04 for Github Actions

### DIFF
--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -8,7 +8,7 @@ env:
 jobs:
 
   rustfmt:
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-20.04
     steps:
       - name: Checkout branch
         uses: actions/checkout@v2
@@ -28,7 +28,7 @@ jobs:
           args: --all --check
 
   tests:
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-20.04
 
     services:
       # Label used to access the service container
@@ -106,7 +106,7 @@ jobs:
           path-to-lcov: ${{ steps.coverage.outputs.report }}
 
   docs:
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-20.04
     needs: [ rustfmt, tests ]
     if: github.ref == 'refs/heads/main'
     steps:
@@ -152,7 +152,7 @@ jobs:
           publish_dir: ./target/doc
 
   deploy:
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-20.04
     env:
       DOCKERHUB_ORG: safeglobal
       DOCKERHUB_PROJECT: safe-client-gateway
@@ -183,7 +183,7 @@ jobs:
         run: bash scripts/deploy_docker.sh develop
 
   autodeploy:
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-20.04
     needs: [deploy]
     if: github.event_name == 'push' && github.ref == 'refs/heads/main'
     steps:


### PR DESCRIPTION
- `ubuntu-latest` is currently set to Ubuntu-22.04 which we have issues with when linking the bundled OpenSSL library.
- `ubuntu-latest` is however in a rollout stage. Therefore, we might either use an instance of Ubuntu-22.04 or Ubuntu-20.04 – see https://github.com/actions/runner-images/issues/6399
- We should set the image to `ubuntu-20.04` until the linking issue with OpenSSL is solved on newer images