### PR TITLE
Remove references to gnosis.io domain

### DIFF
--- a/.env.sample
+++ b/.env.sample
@@ -1,5 +1,5 @@
 # The Base URL of the Safe Config Service (https://github.com/gnosis/safe-config-service)
-CONFIG_SERVICE_URI=https://safe-config.gnosis.io
+CONFIG_SERVICE_URI=https://safe-config.safe.global
 
 # The port exposed to the host by the nginx image.
 NGINX_HOST_PORT=8080

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "safe-client-gateway"
 version = "3.42.0"
-authors = ["jpalvarezl <jose.alvarez@gnosis.io>", "rmeissner <richard@gnosis.io>", "fmrsabino <frederico@gnosis.io>"]
+authors = ["jpalvarezl <jose.alvarez@gnosis.io>", "rmeissner <richard@safe.global>", "fmrsabino <frederico.sabino@safe.global>"]
 edition = "2018"
 
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html

--- a/README.md
+++ b/README.md
@@ -9,8 +9,8 @@ This project is a gateway between the Safe clients ([Android](https://github.com
 ## Documentation
 
 - [Client Gateway Docs](https://safe.global/safe-client-gateway/)
-- [Swagger](https://safe-client.gnosis.io/index.html)
-- [Safe developer documentation](https://docs.gnosis.io/safe/)
+- [Swagger](https://safe-client.safe.global/index.html)
+- [Safe developer documentation](https://docs.gnosis-safe.io/)
 
 ## Quickstart
 

--- a/src/routes/about/tests/routes.rs
+++ b/src/routes/about/tests/routes.rs
@@ -48,7 +48,7 @@ async fn get_chains_about() {
     .expect("valid rocket instance");
     let response = {
         let mut response = client.get("/v1/chains/4/about");
-        response.add_header(Header::new("Host", "test.gnosis.io"));
+        response.add_header(Header::new("Host", "test.safe.global"));
         response.dispatch().await
     };
 
@@ -79,7 +79,7 @@ async fn get_about() {
     .expect("valid rocket instance");
     let response = {
         let mut response = client.get("/about");
-        response.add_header(Header::new("Host", "test.gnosis.io"));
+        response.add_header(Header::new("Host", "test.safe.global"));
         response.dispatch().await
     };
 
@@ -146,7 +146,7 @@ async fn get_master_copies() {
     .expect("valid rocket instance");
     let response = {
         let mut response = client.get("/v1/chains/137/about/master-copies");
-        response.add_header(Header::new("Host", "test.gnosis.io"));
+        response.add_header(Header::new("Host", "test.safe.global"));
         response.dispatch().await
     };
 
@@ -199,7 +199,7 @@ async fn get_backbone() {
     .expect("valid rocket instance");
     let response = {
         let mut response = client.get("/v1/chains/137/about/backbone");
-        response.add_header(Header::new("Host", "test.gnosis.io"));
+        response.add_header(Header::new("Host", "test.safe.global"));
         response.dispatch().await
     };
 
@@ -234,7 +234,7 @@ async fn get_redis() {
     .expect("valid rocket instance");
     let response = {
         let mut response = client.get("/about/redis");
-        response.add_header(Header::new("Host", "test.gnosis.io"));
+        response.add_header(Header::new("Host", "test.safe.global"));
         response.add_header(Header::new("Authorization", "Basic test_webhook_token"));
         response.dispatch().await
     };

--- a/src/routes/chains/tests/json/backend_chains_info_page.json
+++ b/src/routes/chains/tests/json/backend_chains_info_page.json
@@ -1,7 +1,7 @@
 {
     "count": 3,
-    "next": "https://safe-config.gnosis.io/api/v1/chains/?limit=1&offset=2",
-    "previous": "https://safe-config.gnosis.io/api/v1/chains/?limit=1",
+    "next": "https://safe-config.safe.global/api/v1/chains/?limit=1&offset=2",
+    "previous": "https://safe-config.safe.global/api/v1/chains/?limit=1",
     "results": [
         {
             "chainId": "137",

--- a/src/routes/chains/tests/json/expected_chains_info_page.json
+++ b/src/routes/chains/tests/json/expected_chains_info_page.json
@@ -1,6 +1,6 @@
 {
-    "next": "http://test.gnosis.io/api/v1/chains?cursor=limit%3D1%26offset%3D2",
-    "previous": "http://test.gnosis.io/api/v1/chains?cursor=limit%3D1%26offset%3D0",
+    "next": "http://test.safe.global/api/v1/chains?cursor=limit%3D1%26offset%3D2",
+    "previous": "http://test.safe.global/api/v1/chains?cursor=limit%3D1%26offset%3D0",
     "results": [
         {
             "transactionService": "https://safe-transaction-polygon.staging.gnosisdev.com",

--- a/src/routes/chains/tests/routes.rs
+++ b/src/routes/chains/tests/routes.rs
@@ -38,7 +38,7 @@ async fn paginated_chain_infos() {
 
     let request = client
         .get("/v1/chains?cursor=limit%3D1%26offset%3D1")
-        .header(Header::new("Host", "test.gnosis.io/api"))
+        .header(Header::new("Host", "test.safe.global/api"))
         .header(ContentType::JSON);
 
     let response = request.dispatch().await;
@@ -74,7 +74,7 @@ async fn single_chain_info() {
     .expect("valid rocket instance");
     let response = {
         let mut response = client.get("/v1/chains/4");
-        response.add_header(Header::new("Host", "test.gnosis.io"));
+        response.add_header(Header::new("Host", "test.safe.global"));
         response.dispatch().await
     };
     let expected: ChainInfo =

--- a/src/routes/collectibles/routes.rs
+++ b/src/routes/collectibles/routes.rs
@@ -26,7 +26,6 @@ use super::models::Collectible;
 ///
 /// ## Models
 ///
-/// For the most up-to-date version of the endpoint please check: <https://safe-transaction.gnosis.io/>
 ///
 /// ```json
 /// [

--- a/src/routes/collectibles/tests/routes.rs
+++ b/src/routes/collectibles/tests/routes.rs
@@ -57,7 +57,7 @@ async fn collectibles() {
     let response = {
         let mut response = client
             .get("/v1/chains/4/safes/0x1230B3d59858296A31053C1b8562Ecf89A2f888b/collectibles");
-        response.add_header(Header::new("Host", "test.gnosis.io"));
+        response.add_header(Header::new("Host", "test.safe.global"));
         response.dispatch().await
     };
 
@@ -118,7 +118,7 @@ async fn collectibles_not_found() {
     let response = {
         let mut response = client
             .get("/v1/chains/4/safes/0x1230B3d59858296A31053C1b8562Ecf89A2f888b/collectibles");
-        response.add_header(Header::new("Host", "test.gnosis.io"));
+        response.add_header(Header::new("Host", "test.safe.global"));
         response.dispatch().await
     };
 
@@ -172,7 +172,7 @@ async fn collectibles_paginated_empty() {
     let response = {
         let mut response = client
             .get("/v2/chains/4/safes/0x1230B3d59858296A31053C1b8562Ecf89A2f888b/collectibles?cursor=limit%3D10%26offset%3D0&trusted=false&exclude_spam=true");
-        response.add_header(Header::new("Host", "test.gnosis.io"));
+        response.add_header(Header::new("Host", "test.safe.global"));
         response.dispatch().await
     };
 
@@ -227,7 +227,7 @@ async fn collectibles_paginated_page_one() {
     let response = {
         let mut response = client
             .get("/v2/chains/4/safes/0x1230B3d59858296A31053C1b8562Ecf89A2f888b/collectibles?cursor=limit%3D3%26offset%3D0&trusted=false&exclude_spam=true");
-        response.add_header(Header::new("Host", "test.gnosis.io"));
+        response.add_header(Header::new("Host", "test.safe.global"));
         response.dispatch().await
     };
 
@@ -284,7 +284,7 @@ async fn collectibles_paginated_page_two() {
     let response = {
         let mut response = client
             .get("/v2/chains/4/safes/0x1230B3d59858296A31053C1b8562Ecf89A2f888b/collectibles?cursor=limit%3D3%26offset%3D3&trusted=false&exclude_spam=true");
-        response.add_header(Header::new("Host", "test.gnosis.io"));
+        response.add_header(Header::new("Host", "test.safe.global"));
         response.dispatch().await
     };
 

--- a/src/routes/contracts/tests/routes.rs
+++ b/src/routes/contracts/tests/routes.rs
@@ -56,7 +56,7 @@ async fn data_decoded() {
     .await
     .expect("valid rocket instance");
     let request  = client.post("/v1/chains/4/data-decoder")
-        .header(Header::new("Host", "test.gnosis.io"))
+        .header(Header::new("Host", "test.safe.global"))
         .header(ContentType::JSON)
         .body(&json!({"data": "0x095ea7b3000000000000000000000000ae9844f89d98c150f5e61bfc676d68b4921559900000000000000000000000000000000000000000000000000001c6bf52634000"}).to_string());
 
@@ -125,7 +125,7 @@ async fn data_decoded_error() {
     .await
     .expect("valid rocket instance");
     let request  = client.post("/v1/chains/4/data-decoder")
-        .header(Header::new("Host", "test.gnosis.io"))
+        .header(Header::new("Host", "test.safe.global"))
         .header(ContentType::JSON)
         .body(&json!({"data": "0x095ea7b3000000000000000000000000ae9844f89d98c150f5e61bfc676d68b4921559900000000000000000000000000000000000000000000000000001c6bf52634000"}).to_string());
 
@@ -185,7 +185,7 @@ async fn get_contract() {
 
     let request = client
         .get(format!("/v1/chains/4/contracts/{}", &bip_contract_address))
-        .header(Header::new("Host", "test.gnosis.io"))
+        .header(Header::new("Host", "test.safe.global"))
         .header(ContentType::JSON);
 
     let response = request.dispatch().await;
@@ -253,7 +253,7 @@ async fn get_contract_not_found() {
 
     let request = client
         .get(format!("/v1/chains/4/contracts/{}", &bip_contract_address))
-        .header(Header::new("Host", "test.gnosis.io"))
+        .header(Header::new("Host", "test.safe.global"))
         .header(ContentType::JSON);
 
     let response = request.dispatch().await;

--- a/src/routes/delegates/tests/routes.rs
+++ b/src/routes/delegates/tests/routes.rs
@@ -64,7 +64,7 @@ async fn get_delegates_from_safe() {
     // Create request get delegates
     let request = client
         .get(format!("/v1/chains/{}/delegates?safe={}", 4, &safe_address))
-        .header(Header::new("Host", "test.gnosis.io/api"))
+        .header(Header::new("Host", "test.safe.global/api"))
         .header(ContentType::JSON);
     let response = request.dispatch().await;
     let actual_status = response.status();
@@ -127,7 +127,7 @@ async fn add_delegate() {
     let request = client
         .post(format!("/v1/chains/4/delegates"))
         .body(String::from(super::BACKEND_CREATE_DELEGATE))
-        .header(Header::new("Host", "test.gnosis.io/api"))
+        .header(Header::new("Host", "test.safe.global/api"))
         .header(ContentType::JSON);
     let response = request.dispatch().await;
     let actual_status = response.status();
@@ -188,7 +188,7 @@ async fn delete_delegate() {
     let request = client
         .delete(format!("/v1/chains/4/delegates/{}", delegate_address))
         .body(String::from(super::BACKEND_DELETE_DELEGATE))
-        .header(Header::new("Host", "test.gnosis.io/api"))
+        .header(Header::new("Host", "test.safe.global/api"))
         .header(ContentType::JSON);
     let response = request.dispatch().await;
     let actual_status = response.status();
@@ -253,7 +253,7 @@ async fn delete_delegate_safe() {
             safe_address, delegate_address
         ))
         .body(String::from(super::BACKEND_DELETE_DELEGATE_SAFE))
-        .header(Header::new("Host", "test.gnosis.io/api"))
+        .header(Header::new("Host", "test.safe.global/api"))
         .header(ContentType::JSON);
     let response = request.dispatch().await;
     let actual_status = response.status();

--- a/src/routes/health/tests/routes.rs
+++ b/src/routes/health/tests/routes.rs
@@ -15,7 +15,7 @@ async fn health() {
 
     let request = client
         .get("/health")
-        .header(Header::new("Host", "test.gnosis.io"))
+        .header(Header::new("Host", "test.safe.global"))
         .header(ContentType::JSON);
 
     let response = request.dispatch().await;

--- a/src/routes/hooks/tests/routes.rs
+++ b/src/routes/hooks/tests/routes.rs
@@ -24,7 +24,7 @@ async fn post_hooks_events_no_token_set() {
         .post("/v1/chains/1/hooks/events")
         .body(&json!({"address": "0x6810e776880C02933D47DB1b9fc05908e5386b96"}).to_string())
         .header(ContentType::JSON)
-        .header(Header::new("Host", "test.gnosis.io"));
+        .header(Header::new("Host", "test.safe.global"));
     let response = request.dispatch().await;
 
     assert_eq!(response.status(), Status::BadRequest);
@@ -49,7 +49,7 @@ async fn post_hooks_events_invalid_token() {
         .body(&json!({"address": "0x6810e776880C02933D47DB1b9fc05908e5386b96"}).to_string())
         .header(ContentType::JSON)
         .header(Header::new("Authorization", "Basic some_token"))
-        .header(Header::new("Host", "test.gnosis.io"));
+        .header(Header::new("Host", "test.safe.global"));
     let response = request.dispatch().await;
 
     assert_eq!(response.status(), Status::Unauthorized);
@@ -77,7 +77,7 @@ async fn post_hooks_events_valid_token() {
         )
         .header(ContentType::JSON)
         .header(Header::new("Authorization", "Basic test_webhook_token"))
-        .header(Header::new("Host", "test.gnosis.io"));
+        .header(Header::new("Host", "test.safe.global"));
     let response = request.dispatch().await;
 
     assert_eq!(response.status(), Status::Ok);
@@ -99,7 +99,7 @@ async fn post_flush_events_no_token_set() {
     let request = client
         .post("/v2/flush")
         .header(ContentType::JSON)
-        .header(Header::new("Host", "test.gnosis.io"));
+        .header(Header::new("Host", "test.safe.global"));
     let response = request.dispatch().await;
 
     assert_eq!(response.status(), Status::BadRequest);
@@ -122,7 +122,7 @@ async fn post_flush_events_invalid_token() {
     let request = client
         .post("/v2/flush")
         .header(ContentType::JSON)
-        .header(Header::new("Host", "test.gnosis.io"))
+        .header(Header::new("Host", "test.safe.global"))
         .header(Header::new("Authorization", "Basic some_token"));
     let response = request.dispatch().await;
 
@@ -147,7 +147,7 @@ async fn post_flush_events_valid_token() {
         .post("/v2/flush")
         .body(&json!({"invalidate": "Chains"}).to_string())
         .header(ContentType::JSON)
-        .header(Header::new("Host", "test.gnosis.io"))
+        .header(Header::new("Host", "test.safe.global"))
         .header(Header::new("Authorization", "Basic test_webhook_token"));
     let response = request.dispatch().await;
 

--- a/src/routes/notifications/tests/routes.rs
+++ b/src/routes/notifications/tests/routes.rs
@@ -62,7 +62,7 @@ async fn delete_notification_success() {
             "/v1/chains/{}/notifications/devices/{}/safes/{}",
             4, uuid, safe_address
         ))
-        .header(Header::new("Host", "test.gnosis.io"))
+        .header(Header::new("Host", "test.safe.global"))
         .header(ContentType::JSON);
 
     let response = request.dispatch().await;
@@ -122,7 +122,7 @@ async fn delete_notification_error() {
             "/v1/chains/{}/notifications/devices/{}/safes/{}",
             4, uuid, safe_address
         ))
-        .header(Header::new("Host", "test.gnosis.io"))
+        .header(Header::new("Host", "test.safe.global"))
         .header(ContentType::JSON);
 
     let response = request.dispatch().await;
@@ -235,7 +235,7 @@ async fn post_notification_success() {
     let request = client
         .post("/v1/register/notifications")
         .body(&serde_json::to_string(&request).unwrap())
-        .header(Header::new("Host", "test.gnosis.io"))
+        .header(Header::new("Host", "test.safe.global"))
         .header(ContentType::JSON);
 
     let response = request.dispatch().await;
@@ -379,7 +379,7 @@ async fn post_notification_client_error() {
     let request = client
         .post("/v1/register/notifications")
         .body(&serde_json::to_string(&request).unwrap())
-        .header(Header::new("Host", "test.gnosis.io"))
+        .header(Header::new("Host", "test.safe.global"))
         .header(ContentType::JSON);
 
     let response = request.dispatch().await;
@@ -484,7 +484,7 @@ async fn post_notification_server_and_client_errors() {
     let request = client
         .post("/v1/register/notifications")
         .body(&serde_json::to_string(&request).unwrap())
-        .header(Header::new("Host", "test.gnosis.io"))
+        .header(Header::new("Host", "test.safe.global"))
         .header(ContentType::JSON);
     let response = request.dispatch().await;
     let actual_status = response.status();

--- a/src/routes/safe_apps/tests/routes.rs
+++ b/src/routes/safe_apps/tests/routes.rs
@@ -49,7 +49,7 @@ async fn safe_apps() {
     .expect("valid rocket instance");
     let response = {
         let mut response = client.get("/v1/chains/137/safe-apps?client_url=https://gnosis-safe.io");
-        response.add_header(Header::new("Host", "test.gnosis.io"));
+        response.add_header(Header::new("Host", "test.safe.global"));
         response.dispatch().await
     };
     let actual_status = response.status();
@@ -101,7 +101,7 @@ async fn safe_apps_not_found() {
     .expect("valid rocket instance");
     let response = {
         let mut response = client.get("/v1/chains/4/safe-apps");
-        response.add_header(Header::new("Host", "test.gnosis.io"));
+        response.add_header(Header::new("Host", "test.safe.global"));
         response.dispatch().await
     };
 
@@ -144,7 +144,7 @@ async fn safe_apps_tags() {
     .expect("valid rocket instance");
     let response = {
         let mut response = client.get("/v1/chains/137/safe-apps?client_url=https://gnosis-safe.io");
-        response.add_header(Header::new("Host", "test.gnosis.io"));
+        response.add_header(Header::new("Host", "test.safe.global"));
         response.dispatch().await
     };
     let actual_status = response.status();
@@ -195,7 +195,7 @@ async fn safe_apps_url_query_param() {
     let response = {
         let mut response = client
             .get("/v1/chains/137/safe-apps?client_url=https://gnosis-safe.io&url=https://test.app");
-        response.add_header(Header::new("Host", "test.gnosis.io"));
+        response.add_header(Header::new("Host", "test.safe.global"));
         response.dispatch().await
     };
     let actual_status = response.status();

--- a/src/routes/safes/tests/routes.rs
+++ b/src/routes/safes/tests/routes.rs
@@ -147,7 +147,7 @@ async fn get_safe_info() {
 
     let request = client
         .get("/v1/chains/4/safes/0x4cb09344de5bCCD45F045c5Defa0E0452869FF0f")
-        .header(Header::new("Host", "test.gnosis.io"))
+        .header(Header::new("Host", "test.safe.global"))
         .header(ContentType::JSON);
 
     let response = request.dispatch().await;
@@ -213,7 +213,7 @@ async fn get_safe_info_not_found() {
 
     let request = client
         .get("/v1/chains/4/safes/0x4cb09344de5bCCD45F045c5Defa0E0452869FF0f")
-        .header(Header::new("Host", "test.gnosis.io"))
+        .header(Header::new("Host", "test.safe.global"))
         .header(ContentType::JSON);
 
     let response = request.dispatch().await;
@@ -281,7 +281,7 @@ async fn get_owners() {
 
     let request = client
         .get("/v1/chains/4/owners/0x4cb09344de5bCCD45F045c5Defa0E0452869FF0f/safes")
-        .header(Header::new("Host", "test.gnosis.io"))
+        .header(Header::new("Host", "test.safe.global"))
         .header(ContentType::JSON);
 
     let response = request.dispatch().await;
@@ -341,7 +341,7 @@ async fn get_owners_not_found() {
 
     let request = client
         .get("/v1/chains/4/owners/0x4cb09344de5bCCD45F045c5Defa0E0452869FF0f/safes")
-        .header(Header::new("Host", "test.gnosis.io"))
+        .header(Header::new("Host", "test.safe.global"))
         .header(ContentType::JSON);
 
     let response = request.dispatch().await;
@@ -459,7 +459,7 @@ async fn post_safe_gas_estimation() {
             "data": "0x095ea7b3000000000000000000000000ae9844f89d98c150f5e61bfc676d68b4921559900000000000000000000000000000000000000000000000000001c6bf52634000",
             "operation": 0
             }).to_string())
-        .header(Header::new("Host", "test.gnosis.io"))
+        .header(Header::new("Host", "test.safe.global"))
         .header(ContentType::JSON);
 
     let response = request.dispatch().await;
@@ -579,7 +579,7 @@ async fn post_safe_gas_estimation_no_queued_tx() {
             "data": "0x095ea7b3000000000000000000000000ae9844f89d98c150f5e61bfc676d68b4921559900000000000000000000000000000000000000000000000000001c6bf52634000",
             "operation": 0
             }).to_string())
-        .header(Header::new("Host", "test.gnosis.io"))
+        .header(Header::new("Host", "test.safe.global"))
         .header(ContentType::JSON);
 
     let response = request.dispatch().await;
@@ -699,7 +699,7 @@ async fn post_safe_gas_estimation_delayed_indexing() {
             "data": "0x095ea7b3000000000000000000000000ae9844f89d98c150f5e61bfc676d68b4921559900000000000000000000000000000000000000000000000000001c6bf52634000",
             "operation": 0
             }).to_string())
-        .header(Header::new("Host", "test.gnosis.io"))
+        .header(Header::new("Host", "test.safe.global"))
         .header(ContentType::JSON);
 
     let response = request.dispatch().await;
@@ -813,7 +813,7 @@ async fn post_safe_gas_estimation_estimation_error() {
             "data": "0x095ea7b3000000000000000000000000ae9844f89d98c150f5e61bfc676d68b4921559900000000000000000000000000000000000000000000000000001c6bf52634000",
             "operation": 0
             }).to_string())
-        .header(Header::new("Host", "test.gnosis.io"))
+        .header(Header::new("Host", "test.safe.global"))
         .header(ContentType::JSON);
 
     let response = request.dispatch().await;
@@ -897,7 +897,7 @@ async fn post_safe_gas_estimation_nonce_error() {
             "data": "0x095ea7b3000000000000000000000000ae9844f89d98c150f5e61bfc676d68b4921559900000000000000000000000000000000000000000000000000001c6bf52634000",
             "operation": 0
             }).to_string())
-        .header(Header::new("Host", "test.gnosis.io"))
+        .header(Header::new("Host", "test.safe.global"))
         .header(ContentType::JSON);
 
     let response = request.dispatch().await;
@@ -957,7 +957,7 @@ async fn post_safe_gas_estimation_safe_error() {
             "data": "0x095ea7b3000000000000000000000000ae9844f89d98c150f5e61bfc676d68b4921559900000000000000000000000000000000000000000000000000001c6bf52634000",
             "operation": 0
             }).to_string())
-        .header(Header::new("Host", "test.gnosis.io"))
+        .header(Header::new("Host", "test.safe.global"))
         .header(ContentType::JSON);
 
     let response = request.dispatch().await;
@@ -1071,7 +1071,7 @@ async fn post_safe_gas_estimation_v2() {
             "data": "0x095ea7b3000000000000000000000000ae9844f89d98c150f5e61bfc676d68b4921559900000000000000000000000000000000000000000000000000001c6bf52634000",
             "operation": 0
             }).to_string())
-        .header(Header::new("Host", "test.gnosis.io"))
+        .header(Header::new("Host", "test.safe.global"))
         .header(ContentType::JSON);
 
     let response = request.dispatch().await;
@@ -1191,7 +1191,7 @@ async fn post_safe_gas_estimation_v2_no_queued_tx() {
             "data": "0x095ea7b3000000000000000000000000ae9844f89d98c150f5e61bfc676d68b4921559900000000000000000000000000000000000000000000000000001c6bf52634000",
             "operation": 0
             }).to_string())
-        .header(Header::new("Host", "test.gnosis.io"))
+        .header(Header::new("Host", "test.safe.global"))
         .header(ContentType::JSON);
 
     let response = request.dispatch().await;
@@ -1311,7 +1311,7 @@ async fn post_safe_gas_estimation_v2_delayed_indexing() {
             "data": "0x095ea7b3000000000000000000000000ae9844f89d98c150f5e61bfc676d68b4921559900000000000000000000000000000000000000000000000000001c6bf52634000",
             "operation": 0
             }).to_string())
-        .header(Header::new("Host", "test.gnosis.io"))
+        .header(Header::new("Host", "test.safe.global"))
         .header(ContentType::JSON);
 
     let response = request.dispatch().await;
@@ -1425,7 +1425,7 @@ async fn post_safe_gas_estimation_v2_estimation_error() {
             "data": "0x095ea7b3000000000000000000000000ae9844f89d98c150f5e61bfc676d68b4921559900000000000000000000000000000000000000000000000000001c6bf52634000",
             "operation": 0
             }).to_string())
-        .header(Header::new("Host", "test.gnosis.io"))
+        .header(Header::new("Host", "test.safe.global"))
         .header(ContentType::JSON);
 
     let response = request.dispatch().await;
@@ -1509,7 +1509,7 @@ async fn post_safe_gas_estimation_v2_nonce_error() {
             "data": "0x095ea7b3000000000000000000000000ae9844f89d98c150f5e61bfc676d68b4921559900000000000000000000000000000000000000000000000000001c6bf52634000",
             "operation": 0
             }).to_string())
-        .header(Header::new("Host", "test.gnosis.io"))
+        .header(Header::new("Host", "test.safe.global"))
         .header(ContentType::JSON);
 
     let response = request.dispatch().await;
@@ -1569,7 +1569,7 @@ async fn post_safe_gas_estimation_v2_safe_error() {
             "data": "0x095ea7b3000000000000000000000000ae9844f89d98c150f5e61bfc676d68b4921559900000000000000000000000000000000000000000000000000001c6bf52634000",
             "operation": 0
             }).to_string())
-        .header(Header::new("Host", "test.gnosis.io"))
+        .header(Header::new("Host", "test.safe.global"))
         .header(ContentType::JSON);
 
     let response = request.dispatch().await;

--- a/src/routes/transactions/handlers/tests/transfers.rs
+++ b/src/routes/transactions/handlers/tests/transfers.rs
@@ -67,7 +67,7 @@ pub async fn get_incoming_transfers_no_filters() {
             "/v1/chains/4/safes/{}/incoming-transfers",
             &safe_address
         ))
-        .header(Header::new("Host", "test.gnosis.io"))
+        .header(Header::new("Host", "test.safe.global"))
         .header(ContentType::JSON);
 
     let response = request.dispatch().await;

--- a/src/routes/transactions/tests/json/chain_response.json
+++ b/src/routes/transactions/tests/json/chain_response.json
@@ -27,8 +27,8 @@
     "decimals": 18,
     "logoUri": "https://safe-transaction-assets.gnosis-safe.io/chains/1/currency_logo.png"
   },
-  "transactionService": "https://safe-transaction.example.gnosis.io",
-  "vpcTransactionService": "https://safe-transaction.example.gnosis.io",
+  "transactionService": "https://safe-transaction.example.safe.global",
+  "vpcTransactionService": "https://safe-transaction.example.safe.global",
   "theme": {
     "textColor": "#001428",
     "backgroundColor": "#E8E7E6"

--- a/src/routes/transactions/tests/preview.rs
+++ b/src/routes/transactions/tests/preview.rs
@@ -45,7 +45,7 @@ async fn post_preview_success() {
 
         // Known Address Request (to field)
         let mut contract_request = Request::new(format!(
-            "https://safe-transaction.example.gnosis.io/api/v1/contracts/{}/",
+            "https://safe-transaction.example.safe.global/api/v1/contracts/{}/",
             contract_address
         ));
         contract_request.timeout(Duration::from_millis(contract_info_request_timeout()));
@@ -63,7 +63,7 @@ async fn post_preview_success() {
         // Data Decoder Request
         let data = "0x095ea7b3000000000000000000000000ae9844f89d98c150f5e61bfc676d68b4921559900000000000000000000000000000000000000000000000000001c6bf52634000";
         let mut data_decoder_request = Request::new(
-            "https://safe-transaction.example.gnosis.io/api/v1/data-decoder/".to_string(),
+            "https://safe-transaction.example.safe.global/api/v1/data-decoder/".to_string(),
         );
         data_decoder_request.body(Some(
             serde_json::to_string::<DataDecoderRequest>(&DataDecoderRequest {
@@ -96,7 +96,7 @@ async fn post_preview_success() {
     .expect("Valid rocket instance");
 
     let request =  client.post("/v1/chains/1/transactions/0x37D94d4E230859f83c0868CebEd8CcB83A765cee/preview")
-        .header(Header::new("Host", "test.gnosis.io"))
+        .header(Header::new("Host", "test.safe.global"))
         .header(ContentType::JSON)
         .body(&json!({
             "to": "0x37D94d4E230859f83c0868CebEd8CcB83A765cee",
@@ -141,7 +141,7 @@ async fn post_preview_data_decoder_error() {
 
         // Known Address Request (to field)
         let mut contract_request = Request::new(format!(
-            "https://safe-transaction.example.gnosis.io/api/v1/contracts/{}/",
+            "https://safe-transaction.example.safe.global/api/v1/contracts/{}/",
             contract_address
         ));
         contract_request.timeout(Duration::from_millis(contract_info_request_timeout()));
@@ -159,7 +159,7 @@ async fn post_preview_data_decoder_error() {
         // Data Decoder Request
         let data = "0x095ea7b3000000000000000000000000ae9844f89d98c150f5e61bfc676d68b4921559900000000000000000000000000000000000000000000000000001c6bf52634000";
         let mut data_decoder_request = Request::new(
-            "https://safe-transaction.example.gnosis.io/api/v1/data-decoder/".to_string(),
+            "https://safe-transaction.example.safe.global/api/v1/data-decoder/".to_string(),
         );
         data_decoder_request.body(Some(
             serde_json::to_string::<DataDecoderRequest>(&DataDecoderRequest {
@@ -192,7 +192,7 @@ async fn post_preview_data_decoder_error() {
     .expect("Valid rocket instance");
 
     let request =  client.post("/v1/chains/1/transactions/0x37D94d4E230859f83c0868CebEd8CcB83A765cee/preview")
-        .header(Header::new("Host", "test.gnosis.io"))
+        .header(Header::new("Host", "test.safe.global"))
         .header(ContentType::JSON)
         .body(&json!({
             "to": "0x37D94d4E230859f83c0868CebEd8CcB83A765cee",

--- a/src/routes/transactions/tests/routes.rs
+++ b/src/routes/transactions/tests/routes.rs
@@ -128,7 +128,7 @@ async fn post_confirmation_success() {
     .expect("Valid rocket instance");
 
     let request =  client.post("/v1/chains/4/transactions/0x2e4af4b451a493470f38625c5f78f710f02303eb32780896cb55357c00d48faa/confirmations")
-        .header(Header::new("Host", "test.gnosis.io"))
+        .header(Header::new("Host", "test.safe.global"))
         .header(ContentType::JSON)
         .body(&json!({"signedSafeTxHash":"bd42f5c205b544cc6397c8c2e592ca4ade02b8681673cc8c555ff1777b002ee959c3cca243a77a2de1bbe1b61413342ac7d6416a31ec0ff31bb1029e921202ee1c"}).to_string());
     let response = request.dispatch().await;
@@ -198,7 +198,7 @@ async fn post_confirmation_confirmation_error() {
     .expect("Valid rocket instance");
 
     let request =  client.post("/v1/chains/4/transactions/0x2e4af4b451a493470f38625c5f78f710f02303eb32780896cb55357c00d48faa/confirmations")
-        .header(Header::new("Host", "test.gnosis.io"))
+        .header(Header::new("Host", "test.safe.global"))
         .header(ContentType::JSON)
         .body(&json!({"signedSafeTxHash":"bd42f5c205b544cc6397c8c2e592ca4ade02b8681673cc8c555ff1777b002ee959c3cca243a77a2de1bbe1b61413342ac7d6416a31ec0ff31bb1029e921202ee1c"}).to_string());
     let response = request.dispatch().await;
@@ -282,7 +282,7 @@ async fn post_confirmation_confirmation_success_tx_details_error() {
     .expect("Valid rocket instance");
 
     let request =  client.post("/v1/chains/4/transactions/0x2e4af4b451a493470f38625c5f78f710f02303eb32780896cb55357c00d48faa/confirmations")
-        .header(Header::new("Host", "test.gnosis.io"))
+        .header(Header::new("Host", "test.safe.global"))
         .header(ContentType::JSON)
         .body(&json!({"signedSafeTxHash":"bd42f5c205b544cc6397c8c2e592ca4ade02b8681673cc8c555ff1777b002ee959c3cca243a77a2de1bbe1b61413342ac7d6416a31ec0ff31bb1029e921202ee1c"}).to_string());
     let response = request.dispatch().await;
@@ -413,7 +413,7 @@ async fn tx_details_multisig_tx_success() {
     .expect("Valid rocket instance");
 
     let request =  client.get("/v1/chains/4/transactions/0x2e4af4b451a493470f38625c5f78f710f02303eb32780896cb55357c00d48faa/")
-        .header(Header::new("Host", "test.gnosis.io"));
+        .header(Header::new("Host", "test.safe.global"));
     let response = request.dispatch().await;
 
     let expected = serde_json::from_str::<TransactionDetails>(MULTISIG_TX_DETAILS).unwrap();

--- a/src/tests/backend_url.rs
+++ b/src/tests/backend_url.rs
@@ -12,7 +12,7 @@ async fn core_uri_success_with_params_prod() {
     let exclude_spam = true;
     let chain_info = ChainInfo {
         recommended_master_copy_version: "1.1.1".to_string(),
-        transaction_service: "https://safe-transaction.mainnet.gnosis.io".to_string(),
+        transaction_service: "https://safe-transaction.mainnet.safe.global".to_string(),
         vpc_transaction_service: "http://mainnet-safe-transaction-web.safe.svc.cluster.local"
             .to_string(),
         chain_id: "1".to_string(),
@@ -75,7 +75,7 @@ async fn core_uri_success_without_params_prod() {
     std::env::set_var("VPC_TRANSACTION_SERVICE_URI", "true");
     let chain_info = ChainInfo {
         recommended_master_copy_version: "1.1.1".to_string(),
-        transaction_service: "https://safe-transaction.mainnet.gnosis.io".to_string(),
+        transaction_service: "https://safe-transaction.mainnet.safe.global".to_string(),
         vpc_transaction_service: "http://mainnet-safe-transaction-web.safe.svc.cluster.local"
             .to_string(),
         chain_id: "1".to_string(),
@@ -138,7 +138,7 @@ async fn core_uri_success_with_params_local() {
     let exclude_spam = true;
     let chain_info = ChainInfo {
         recommended_master_copy_version: "1.1.1".to_string(),
-        transaction_service: "https://safe-transaction.mainnet.gnosis.io".to_string(),
+        transaction_service: "https://safe-transaction.mainnet.safe.global".to_string(),
         vpc_transaction_service: "http://mainnet-safe-transaction-web.safe.svc.cluster.local"
             .to_string(),
         chain_id: "1".to_string(),
@@ -193,7 +193,7 @@ async fn core_uri_success_with_params_local() {
         exclude_spam
     );
 
-    assert_eq!(url.unwrap(), "https://safe-transaction.mainnet.gnosis.io/api/v1/safes/0x1230B3d59858296A31053C1b8562Ecf89A2f888b/balances/usd/?trusted=false&exclude_spam=true".to_string());
+    assert_eq!(url.unwrap(), "https://safe-transaction.mainnet.safe.global/api/v1/safes/0x1230B3d59858296A31053C1b8562Ecf89A2f888b/balances/usd/?trusted=false&exclude_spam=true".to_string());
 }
 
 #[rocket::async_test]
@@ -201,7 +201,7 @@ async fn core_uri_success_without_params_local() {
     std::env::set_var("VPC_TRANSACTION_SERVICE_URI", "false");
     let chain_info = ChainInfo {
         recommended_master_copy_version: "1.1.1".to_string(),
-        transaction_service: "https://safe-transaction.mainnet.gnosis.io".to_string(),
+        transaction_service: "https://safe-transaction.mainnet.safe.global".to_string(),
         vpc_transaction_service: "http://mainnet-safe-transaction-web.safe.svc.cluster.local"
             .to_string(),
         chain_id: "1".to_string(),
@@ -251,7 +251,7 @@ async fn core_uri_success_without_params_local() {
     let url = core_uri!(mock_info_provider, "/some/path");
 
     assert_eq!(
-        "https://safe-transaction.mainnet.gnosis.io/api/some/path",
+        "https://safe-transaction.mainnet.safe.global/api/some/path",
         url.unwrap()
     );
 }

--- a/src/tests/json/collectibles/collectibles_paginated_page_1_cgw.json
+++ b/src/tests/json/collectibles/collectibles_paginated_page_1_cgw.json
@@ -1,5 +1,5 @@
 {
-"next": "http://test.gnosis.io/v2/chains/4/safes/0x1230B3d59858296A31053C1b8562Ecf89A2f888b/collectibles?cursor=limit%3D3%26offset%3D3&trusted=false&exclude_spam=true", 
+"next": "http://test.safe.global/v2/chains/4/safes/0x1230B3d59858296A31053C1b8562Ecf89A2f888b/collectibles?cursor=limit%3D3%26offset%3D3&trusted=false&exclude_spam=true", 
 "previous": null, 
 "results":[
     {

--- a/src/tests/json/collectibles/collectibles_paginated_page_2_cgw.json
+++ b/src/tests/json/collectibles/collectibles_paginated_page_2_cgw.json
@@ -1,6 +1,6 @@
 {
     "next": null, 
-    "previous": "http://test.gnosis.io/v2/chains/4/safes/0x1230B3d59858296A31053C1b8562Ecf89A2f888b/collectibles?cursor=limit%3D3%26offset%3D0&trusted=false&exclude_spam=true", 
+    "previous": "http://test.safe.global/v2/chains/4/safes/0x1230B3d59858296A31053C1b8562Ecf89A2f888b/collectibles?cursor=limit%3D3%26offset%3D0&trusted=false&exclude_spam=true", 
     "results":
     [
     {


### PR DESCRIPTION
- Replaces `gnosis.io` references with `safe.global`
- Changes the authors email @rmeissner and @fmrsabino with a `safe.global` email
- Updates README.md links:
  * Swagger now points to https://safe-client.safe.global/index.html
  * Safe developer documentation now points to https://docs.gnosis-safe.io/
