### PR TITLE
Bump openssl from 0.10.30 to 0.10.44

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1502,16 +1502,28 @@ checksum = "624a8340c38c1b80fd549087862da4ba43e08858af025b236e509b6649fc13d5"
 
 [[package]]
 name = "openssl"
-version = "0.10.30"
+version = "0.10.44"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8d575eff3665419f9b83678ff2815858ad9d11567e082f5ac1814baba4e2bcb4"
+checksum = "29d971fd5722fec23977260f6e81aa67d2f22cadbdc2aa049f1022d9a3be1566"
 dependencies = [
  "bitflags",
- "cfg-if 0.1.10",
+ "cfg-if 1.0.0",
  "foreign-types",
- "lazy_static",
  "libc",
+ "once_cell",
+ "openssl-macros",
  "openssl-sys",
+]
+
+[[package]]
+name = "openssl-macros"
+version = "0.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b501e44f11665960c7e7fcf062c7d96a14ade4aa98116c004b2e37b5be7d736c"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
 ]
 
 [[package]]
@@ -1522,9 +1534,9 @@ checksum = "77af24da69f9d9341038eba93a073b1fdaaa1b788221b00a69bce9e762cb32de"
 
 [[package]]
 name = "openssl-sys"
-version = "0.9.59"
+version = "0.9.79"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "de52d8eabd217311538a39bba130d7dea1f1e118010fee7a033d966845e7d5fe"
+checksum = "5454462c0eced1e97f2ec09036abc8da362e66802f66fd20f86854d9d8cbcbc4"
 dependencies = [
  "autocfg",
  "cc",


### PR DESCRIPTION
Closes https://github.com/safe-global/safe-client-gateway/issues/1029

- Updates `openssl` dependency from `0.10.30` to `0.10.44`
- This new version supports both OpenSSL 1.1.1 and OpenSSL 3

We depend on `openssl` via a transitive dependency – `native-tls`:

```
native-tls v0.2.10
├── hyper-tls v0.5.0
│   └── reqwest v0.11.13
│       └── safe-client-gateway
```

`native-tls v0.2.10` requires any minor version of `v0` of the `openssl` create. Support for OpenSSL 3 was added in [v0.10.35](https://github.com/sfackler/rust-openssl/compare/openssl-v0.10.34...openssl-v0.10.35) https://github.com/sfackler/rust-openssl/blob/master/openssl/CHANGELOG.md#v01035---2021-06-18
