### PR TITLE
Backmerge release 3.45.0

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2241,7 +2241,7 @@ checksum = "71d301d4193d031abdd79ff7e3dd721168a9572ef3fe51a1517aba235bd8f86e"
 
 [[package]]
 name = "safe-client-gateway"
-version = "3.43.0"
+version = "3.45.0"
 dependencies = [
  "bb8-redis",
  "bigdecimal",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "safe-client-gateway"
-version = "3.43.0"
+version = "3.45.0"
 authors = ["jpalvarezl <jose.alvarez@gnosis.io>", "rmeissner <richard@safe.global>", "fmrsabino <frederico.sabino@safe.global>"]
 edition = "2018"
 


### PR DESCRIPTION
Release: https://github.com/safe-global/safe-client-gateway/releases/tag/v3.45.0