### PR TITLE
Remove Safe Apps Tags feature flag

### DIFF
--- a/.env.sample
+++ b/.env.sample
@@ -13,9 +13,6 @@ FEATURE_FLAG_NESTED_DECODING=true
 FEATURE_FLAG_BALANCES_RATE_IMPLEMENTATION=false
 FEATURE_PREVIEW_ENDPOINT=true
 
-# Enables the tags feature for Safe Apps
-SAFE_APPS_TAGS_FEATURE_ENABLED=false
-
 # Random string (generated with openssl rand -base64 32)
 # [string] a 256-bit base64 encoded string (44 characters) to use as the secret key
 ROCKET_SECRET_KEY=Qt6DPFUU8qO4BKTCQnKAgt9FBBJxIWAYUGyHuruVfpE=

--- a/src/common/models/backend/safe_apps.rs
+++ b/src/common/models/backend/safe_apps.rs
@@ -11,7 +11,6 @@ pub struct SafeApp {
     pub chain_ids: Vec<u64>,
     pub provider: Option<SafeAppProvider>,
     pub access_control: SafeAppAccessControlPolicies,
-    // We set this value as a default since this feature might not be enabled yet. See SAFE_APPS_TAGS_FEATURE_ENABLED
     #[serde(default)]
     pub tags: Vec<String>,
 }

--- a/src/config/mod.rs
+++ b/src/config/mod.rs
@@ -181,10 +181,6 @@ pub fn is_preview_endpoint_enabled() -> bool {
     env_with_default("FEATURE_PREVIEW_ENDPOINT", false)
 }
 
-pub fn is_safe_apps_tags_feature_enabled() -> bool {
-    env_with_default("SAFE_APPS_TAGS_FEATURE_ENABLED", false)
-}
-
 pub fn vpc_transaction_service_uri() -> bool {
     env_with_default("VPC_TRANSACTION_SERVICE_URI", true)
 }

--- a/src/routes/safe_apps/models.rs
+++ b/src/routes/safe_apps/models.rs
@@ -1,7 +1,5 @@
 use serde::Serialize;
 
-use crate::config::is_safe_apps_tags_feature_enabled;
-
 #[derive(Serialize, Debug, PartialEq, Clone)]
 #[serde(rename_all = "camelCase")]
 #[cfg_attr(test, derive(serde::Deserialize))]
@@ -14,14 +12,9 @@ pub struct SafeApp {
     pub chain_ids: Vec<String>,
     pub provider: Option<SafeAppProvider>,
     pub access_control: SafeAppAccessControlPolicies,
-    #[serde(skip_serializing_if = "should_skip_serializing_tags")]
     // We deserialize this for testing so it would break since the value wouldn't be present
     #[serde(default)]
     pub tags: Vec<String>,
-}
-
-pub fn should_skip_serializing_tags(_tags: &Vec<String>) -> bool {
-    return !is_safe_apps_tags_feature_enabled();
 }
 
 #[derive(Serialize, Debug, PartialEq, Clone)]

--- a/src/routes/safe_apps/tests/routes.rs
+++ b/src/routes/safe_apps/tests/routes.rs
@@ -15,7 +15,6 @@ use super::RESPONSE_SAFE_APPS;
 
 #[rocket::async_test]
 async fn safe_apps() {
-    env::set_var("SAFE_APPS_TAGS_FEATURE_ENABLED", "false");
     let chain_id = "137";
     let client_url = "https://gnosis-safe.io";
 
@@ -63,7 +62,6 @@ async fn safe_apps() {
 
 #[rocket::async_test]
 async fn safe_apps_not_found() {
-    env::set_var("SAFE_APPS_TAGS_FEATURE_ENABLED", "false");
     let chain_id = "4";
     let backend_error_json = json!({"details": "Not found"}).to_string();
     let error = ErrorDetails {
@@ -114,7 +112,6 @@ async fn safe_apps_not_found() {
 
 #[rocket::async_test]
 async fn safe_apps_tags() {
-    env::set_var("SAFE_APPS_TAGS_FEATURE_ENABLED", "true");
     let chain_id = "137";
     let client_url = "https://gnosis-safe.io";
     let mut mock_http_client = MockHttpClient::new();
@@ -158,7 +155,6 @@ async fn safe_apps_tags() {
 
 #[rocket::async_test]
 async fn safe_apps_url_query_param() {
-    env::set_var("SAFE_APPS_TAGS_FEATURE_ENABLED", "false");
     let chain_id = "137";
     let client_url = "https://gnosis-safe.io";
     let url = "https://test.app";


### PR DESCRIPTION
- Removes `SAFE_APPS_TAGS_FEATURE_ENABLED` since we consider this feature to be stable and part of the API that we offer