### PR TITLE
Remove FEATURE_PREVIEW_ENDPOINT flag

### DIFF
--- a/.env.sample
+++ b/.env.sample
@@ -11,7 +11,6 @@ NGINX_ENVSUBST_OUTPUT_DIR=/etc/nginx/
 # Feature Flags
 FEATURE_FLAG_NESTED_DECODING=true
 FEATURE_FLAG_BALANCES_RATE_IMPLEMENTATION=false
-FEATURE_PREVIEW_ENDPOINT=true
 
 # Random string (generated with openssl rand -base64 32)
 # [string] a 256-bit base64 encoded string (44 characters) to use as the secret key

--- a/src/config/mod.rs
+++ b/src/config/mod.rs
@@ -177,10 +177,6 @@ pub fn is_messages_feature_enabled() -> bool {
     env_with_default("FEATURE_MESSAGES", false)
 }
 
-pub fn is_preview_endpoint_enabled() -> bool {
-    env_with_default("FEATURE_PREVIEW_ENDPOINT", false)
-}
-
 pub fn vpc_transaction_service_uri() -> bool {
     env_with_default("VPC_TRANSACTION_SERVICE_URI", true)
 }

--- a/src/routes/mod.rs
+++ b/src/routes/mod.rs
@@ -3,7 +3,7 @@ use rocket::serde::json::{json, Value};
 use rocket::{Catcher, Route};
 use rocket_okapi::openapi_get_routes;
 
-use crate::config::{is_messages_feature_enabled, is_preview_endpoint_enabled};
+use crate::config::is_messages_feature_enabled;
 
 /// # About endpoint
 pub mod about;
@@ -44,6 +44,7 @@ pub fn active_routes() -> Vec<Route> {
         safes::routes::post_safe_gas_estimation,
         safes::routes::post_safe_gas_estimation_v2,
         transactions::routes::post_confirmation,
+        transactions::routes::post_preview_transaction,
         transactions::routes::post_transaction,
         // This endpoints shouldn't be exposed on swagger
         about::routes::redis,
@@ -53,12 +54,6 @@ pub fn active_routes() -> Vec<Route> {
         hooks::routes::post_flush_events,
         hooks::routes::flush,
     ];
-
-    let preview_route = if is_preview_endpoint_enabled() {
-        routes![transactions::routes::post_preview_transaction]
-    } else {
-        routes![]
-    };
 
     let messages_routes = if is_messages_feature_enabled() {
         routes![
@@ -99,13 +94,7 @@ pub fn active_routes() -> Vec<Route> {
         transactions::routes::get_multisig_transactions,
         health::routes::health
     ];
-    return [
-        &no_openapi[..],
-        &preview_route[..],
-        &messages_routes[..],
-        &openapi[..],
-    ]
-    .concat();
+    return [&no_openapi[..], &messages_routes[..], &openapi[..]].concat();
 }
 
 #[doc(hidden)]


### PR DESCRIPTION
- Removes `FEATURE_PREVIEW_ENDPOINT` feature flag
- This flag was used to enable/disable the `/preview` route on the service
- We now consider the `/preview` endpoint as part of the main API offered by the Safe Client Gateway
