### PR TITLE
Use build-push-action instead of custom script

### DIFF
--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -151,13 +151,45 @@ jobs:
           github_token: ${{ secrets.GITHUB_TOKEN }}
           publish_dir: ./target/doc
 
+  docker-publish-staging:
+    if: (github.event_name == 'push' && github.ref == 'refs/heads/main')
+    needs: [ rustfmt, tests ]
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v3
+        with:
+          # Number of commits to fetch. 0 indicates all history for all branches and tags.
+          fetch-depth: '0'
+      - name: Set Version
+        run: |
+          description="$(git describe --tags --always)"
+          echo "VERSION=${description:1}" >> $GITHUB_ENV
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v2.4.1
+      - name: Login to DockerHub
+        uses: docker/login-action@v2.1.0
+        with:
+          username: ${{ secrets.DOCKER_USER }}
+          password: ${{ secrets.DOCKER_PASSWORD }}
+      - name: Build and push
+        uses: docker/build-push-action@v4.0.0
+        with:
+          context: .
+          push: true
+          build-args: VERSION=${{ env.VERSION }}
+          tags: safeglobal/safe-client-gateway:staging
+          cache-from: type=registry,ref=safeglobal/safe-client-gateway:staging
+          cache-to: type=inline
+
+
   deploy:
     runs-on: ubuntu-20.04
     env:
       DOCKERHUB_ORG: safeglobal
       DOCKERHUB_PROJECT: safe-client-gateway
     needs: [ rustfmt, tests ]
-    if: github.ref == 'refs/heads/main' || github.ref == 'refs/heads/develop' || startsWith(github.ref, 'refs/tags/v')
+    if: github.ref == 'refs/heads/develop' || startsWith(github.ref, 'refs/tags/v')
     steps:
       - name: Checkout branch
         uses: actions/checkout@v3
@@ -184,7 +216,7 @@ jobs:
 
   autodeploy:
     runs-on: ubuntu-20.04
-    needs: [deploy]
+    needs: [docker-publish-staging]
     if: github.event_name == 'push' && github.ref == 'refs/heads/main'
     steps:
     - uses: actions/checkout@v3


### PR DESCRIPTION
- Adds `docker-publish-staging` – this job is responsible for building and uploading a Docker image with the `staging` tag
- It retrieves the image cache layers from Dockerhub Registry – see https://docs.docker.com/build/cache/backends/inline/
- Removes the condition which would trigger the deployment from `main` branch in the `deploy` job (as this is already covered by `docker-publish-staging`.
