### PR TITLE
Push ARM64 and AMD64 Docker images

### DIFF
--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -160,7 +160,12 @@ jobs:
         uses: actions/checkout@v3
         with:
           # Number of commits to fetch. 0 indicates all history for all branches and tags.
+          # This is needed for the "Set Version" step as we need to fetch the available tags
           fetch-depth: '0'
+      - name: Set up QEMU
+        uses: docker/setup-qemu-action@v2.1.0
+        with:
+          platforms: arm64
       - name: Set Version
         run: |
           description="$(git describe --tags --always)"
@@ -176,6 +181,7 @@ jobs:
         uses: docker/build-push-action@v4.0.0
         with:
           context: .
+          platforms: linux/amd64,linux/arm64
           push: true
           build-args: VERSION=${{ env.VERSION }}
           tags: safeglobal/safe-client-gateway:staging
@@ -216,13 +222,13 @@ jobs:
 
   autodeploy:
     runs-on: ubuntu-20.04
-    needs: [docker-publish-staging]
+    needs: [ docker-publish-staging ]
     if: github.event_name == 'push' && github.ref == 'refs/heads/main'
     steps:
-    - uses: actions/checkout@v3
-    - name: Deploy staging
-      run: bash scripts/autodeploy.sh
-      env:
-        AUTODEPLOY_URL: ${{ secrets.AUTODEPLOY_URL }}
-        AUTODEPLOY_TOKEN: ${{ secrets.AUTODEPLOY_TOKEN }}
-        TARGET_ENV: "staging"
+      - uses: actions/checkout@v3
+      - name: Deploy staging
+        run: bash scripts/autodeploy.sh
+        env:
+          AUTODEPLOY_URL: ${{ secrets.AUTODEPLOY_URL }}
+          AUTODEPLOY_TOKEN: ${{ secrets.AUTODEPLOY_TOKEN }}
+          TARGET_ENV: "staging"


### PR DESCRIPTION
- `docker-publish-staging` now publishes both `linux/amd66` and `linux/arm64` images
- Formats `autodeploy` step (indentation/spaces)
