### PR TITLE
Add support for linux/arm64 cross compilation

### DIFF
--- a/.cargo/config.toml
+++ b/.cargo/config.toml
@@ -1,0 +1,2 @@
+[target.aarch64-unknown-linux-gnu]
+linker = "aarch64-linux-gnu-gcc"

--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -160,7 +160,12 @@ jobs:
         uses: actions/checkout@v3
         with:
           # Number of commits to fetch. 0 indicates all history for all branches and tags.
+          # This is needed for the "Set Version" step as we need to fetch the available tags
           fetch-depth: '0'
+      - name: Set up QEMU
+        uses: docker/setup-qemu-action@v2.1.0
+        with:
+          platforms: arm64
       - name: Set Version
         run: |
           description="$(git describe --tags --always)"
@@ -176,6 +181,7 @@ jobs:
         uses: docker/build-push-action@v4.0.0
         with:
           context: .
+          platforms: linux/amd64,linux/arm64
           push: true
           build-args: VERSION=${{ env.VERSION }}
           tags: safeglobal/safe-client-gateway:staging
@@ -216,13 +222,13 @@ jobs:
 
   autodeploy:
     runs-on: ubuntu-20.04
-    needs: [docker-publish-staging]
+    needs: [ docker-publish-staging ]
     if: github.event_name == 'push' && github.ref == 'refs/heads/main'
     steps:
-    - uses: actions/checkout@v3
-    - name: Deploy staging
-      run: bash scripts/autodeploy.sh
-      env:
-        AUTODEPLOY_URL: ${{ secrets.AUTODEPLOY_URL }}
-        AUTODEPLOY_TOKEN: ${{ secrets.AUTODEPLOY_TOKEN }}
-        TARGET_ENV: "staging"
+      - uses: actions/checkout@v3
+      - name: Deploy staging
+        run: bash scripts/autodeploy.sh
+        env:
+          AUTODEPLOY_URL: ${{ secrets.AUTODEPLOY_URL }}
+          AUTODEPLOY_TOKEN: ${{ secrets.AUTODEPLOY_TOKEN }}
+          TARGET_ENV: "staging"

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1539,6 +1539,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "77af24da69f9d9341038eba93a073b1fdaaa1b788221b00a69bce9e762cb32de"
 
 [[package]]
+name = "openssl-src"
+version = "111.25.0+1.1.1t"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3173cd3626c43e3854b1b727422a276e568d9ec5fe8cec197822cf52cfb743d6"
+dependencies = [
+ "cc",
+]
+
+[[package]]
 name = "openssl-sys"
 version = "0.9.79"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1547,6 +1556,7 @@ dependencies = [
  "autocfg",
  "cc",
  "libc",
+ "openssl-src",
  "pkg-config",
  "vcpkg",
 ]
@@ -2261,6 +2271,7 @@ dependencies = [
  "lazy_static",
  "log",
  "mockall",
+ "openssl",
  "r2d2",
  "rand 0.8.5",
  "regex",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -19,13 +19,14 @@ itertools = "0.10.5"
 lazy_static = "1.4.0"
 log = "0.4.17"
 mockall = "0.11.3"
+openssl = { version = "0.10", features = ["vendored"] }
 rand = "0.8.5"
 r2d2 = "0.8.10"
 regex = "1.7.1"
 reqwest = { version = "0.11.14", features = ["json"] }
 rocket = { version = "0.5.0-rc.2", features = ["tls", "json"] }
 rocket_codegen = { version = "0.5.0-rc.2" }
-rocket_okapi = { version="0.8.0-rc.2", features = ["swagger"] }
+rocket_okapi = { version = "0.8.0-rc.2", features = ["swagger"] }
 semver = "1.0.16"
 serde = { version = "1.0.152", features = ["derive"] }
 serde_json = { version = "1.0.94", features = ["raw_value"] }

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,47 +1,61 @@
 # Build Image
 # match with version in rust-toolchain.toml file
-FROM rust:1.65.0-slim-buster as builder
+# BUILDPLATFORM is available inside Docker context. It contains the name of the host platform
+# See https://docs.docker.com/build/building/multi-platform/#building-multi-platform-images
+# See https://jakewharton.com/cross-compiling-static-rust-binaries-in-docker-for-raspberry-pi/
+FROM --platform=$BUILDPLATFORM rust:1.65.0 as builder
 
-RUN set -ex; \ 
-  apt-get update; \
-  apt-get install -y --no-install-recommends \
-  pkg-config ca-certificates libssl-dev \
-  && rm -rf /var/lib/apt/lists/*
-
-ENV USER=root
-WORKDIR "/app"
-# Cache dependencies
-# We copy the toolchain requirements first. 
-# This will make it possible that all the stages after the init can be cached.
-COPY rust-toolchain.toml rust-toolchain.toml
-RUN cargo init
-COPY Cargo.toml Cargo.toml
-COPY Cargo.lock Cargo.lock
-RUN cargo build --release --locked
-
-COPY . .
-
+# TARGETPLATFORM is available inside the Docker context. It contains the name of the target platform
+# See https://docs.docker.com/build/building/multi-platform/#building-multi-platform-images
+ARG TARGETPLATFORM
 ARG VERSION
 ARG BUILD_NUMBER
-# Remove fingerprint of app to force recompile (without dependency recompile)
-RUN rm -rf target/release/.fingerprint/safe-client-gateway*
-RUN cargo build --release --locked
 
-# Runtime Image
-FROM debian:buster-slim
+# This Docker image supports two targets: linux/arm64 and linux/amd64
+# In order to install the correct Rust build tools for each target we map the buildx targets to a rust target.
+# The mapping result is then written to rust_target.txt
+RUN case "$TARGETPLATFORM" in \
+      "linux/arm64") echo aarch64-unknown-linux-gnu > /rust_target.txt ;; \
+      "linux/amd64") echo x86_64-unknown-linux-gnu > /rust_target.txt ;; \
+      *) exit 1 ;; \
+    esac
 
+# If the target platform is linux/arm64 we need to additionally configure the Ring crate which is used by this project
+# This setup specifies the correct linker to be used when targetting aarch64-unknown-linux-gnu
+# See: https://github.com/briansmith/ring/blob/main/BUILDING.md#cross-compiling
+RUN if [ "$TARGETPLATFORM" = "linux/arm64" ] ; then \
+    export CC_aarch64_unknown_linux_gnu=clang && \
+    export AR_aarch64_unknown_linux_gnu=llvm-ar && \
+    export CFLAGS_aarch64_unknown_linux_gnu="--sysroot=/usr/aarch64-linux-gnu" && \
+    export CARGO_TARGET_AARCH64_UNKNOWN_LINUX_GNU_LINKER=aarch64-linux-gnu-gcc && \
+    export CARGO_TARGET_AARCH64_UNKNOWN_LINUX_GNU_RUNNER="qemu-aarch64 -L /usr/aarch64-linux-gnu"; \
+    fi
+
+# Install the necessary Rust tooling to build for the target obtained from TARGETPLATFORM
+RUN rustup target add $(cat /rust_target.txt)
+
+# If we are targetting linux/arm64 we need to install some additional build tools
+# See: https://github.com/briansmith/ring/blob/main/BUILDING.md#cross-compiling
+RUN if [ "$TARGETPLATFORM" = "linux/arm64" ] ;  \
+    then apt-get update && apt-get install -y \
+    clang llvm gcc-aarch64-linux-gnu libc6-dev-arm64-cross && \
+    rm -rf /var/lib/apt/lists/*;  \
+    fi
 
 WORKDIR "/app"
+COPY .cargo ./.cargo
+COPY Cargo.toml Cargo.lock ./
+COPY src ./src
+RUN cargo build --release --locked --target $(cat /rust_target.txt)
+# Copy the project to a target independent location. This will be used by the Runtime image
+RUN cp target/$(cat /rust_target.txt)/release/safe-client-gateway .
 
-ENV APP_USER=rust ROCKET_ENV=production ROCKET_ADDRESS=0.0.0.0 ROCKET_PORT=3666
+# Runtime Image
+FROM debian:bullseye-slim
+WORKDIR "/app"
+
+ENV ROCKET_ENV=production ROCKET_ADDRESS=0.0.0.0 ROCKET_PORT=3666
 EXPOSE $ROCKET_PORT
-RUN useradd $APP_USER
 
-RUN set -ex; \ 
-  apt-get update; \
-  apt-get install -y --no-install-recommends \
-  ca-certificates libssl-dev \
-  && rm -rf /var/lib/apt/lists/*
-
-COPY --from=builder --chown=rust:rust /app/target/release/safe-client-gateway ./
+COPY --from=builder /app/safe-client-gateway ./
 CMD ["./safe-client-gateway"]


### PR DESCRIPTION
- Adds support to compile to a `linux/arm64` target from a `linux/amd64` host.
- Specifies the linker for ARM64 targets in `.cargo/config.toml`
- Use the `vendored` feature from the `openssl` crate to compile the OpenSSL source and link it in the target architecture.
- Removes `ca-certificates` `libssl-dev` from the dependencies required from the runtime image (they are not required)
- `docker-publish-staging` now publishes both `linux/amd64` and `linux/arm64` images
- Formats `autodeploy` step (indentation/spaces)